### PR TITLE
feat: better generic args

### DIFF
--- a/examples/delta.rs
+++ b/examples/delta.rs
@@ -14,7 +14,7 @@ use spark_connect_rs::dataframe::SaveMode;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut spark: SparkSession = SparkSessionBuilder::default().build().await?;
 
-    let paths = vec!["/opt/spark/examples/src/main/resources/people.csv".to_string()];
+    let paths = ["/opt/spark/examples/src/main/resources/people.csv"];
 
     let df = spark
         .clone()

--- a/examples/reader.rs
+++ b/examples/reader.rs
@@ -9,16 +9,16 @@ use spark_connect_rs::functions as F;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spark: SparkSession = SparkSessionBuilder::default().build().await?;
 
-    let paths = vec!["/opt/spark/examples/src/main/resources/people.csv".to_string()];
+    let path = ["/opt/spark/examples/src/main/resources/people.csv"];
 
     let mut df = spark
         .read()
         .format("csv")
         .option("header", "True")
         .option("delimiter", ";")
-        .load(paths);
+        .load(path);
 
-    df.select(vec![
+    df.select([
         F::col("name"),
         F::col("age").cast("int").alias("age_int"),
         (F::lit(3.0) + F::col("age").cast("int")).alias("addition"),

--- a/examples/writer.rs
+++ b/examples/writer.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .read()
         .format("csv")
         .option("header", "true")
-        .load(vec![path.to_string()]);
+        .load([path]);
 
     df.show(Some(10), None, None).await?;
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -54,7 +54,9 @@ impl Catalog {
 
     /// Returns a list of catalogs in this session
     #[allow(non_snake_case)]
-    pub async fn listCatalogs(&mut self, pattern: Option<String>) -> Vec<RecordBatch> {
+    pub async fn listCatalogs(&mut self, pattern: Option<&str>) -> Vec<RecordBatch> {
+        let pattern = pattern.map(|val| val.to_owned());
+
         let cat_type = Some(spark::catalog::CatType::ListCatalogs(spark::ListCatalogs {
             pattern,
         }));
@@ -72,7 +74,9 @@ impl Catalog {
 
     /// Returns a list of databases in this session
     #[allow(non_snake_case)]
-    pub async fn listDatabases(&mut self, pattern: Option<String>) -> Vec<RecordBatch> {
+    pub async fn listDatabases(&mut self, pattern: Option<&str>) -> Vec<RecordBatch> {
+        let pattern = pattern.map(|val| val.to_owned());
+
         let cat_type = Some(spark::catalog::CatType::ListDatabases(
             spark::ListDatabases { pattern },
         ));
@@ -92,12 +96,12 @@ impl Catalog {
     #[allow(non_snake_case)]
     pub async fn listTables(
         &mut self,
-        dbName: Option<String>,
-        pattern: Option<String>,
+        dbName: Option<&str>,
+        pattern: Option<&str>,
     ) -> Vec<RecordBatch> {
         let cat_type = Some(spark::catalog::CatType::ListTables(spark::ListTables {
-            db_name: dbName,
-            pattern,
+            db_name: dbName.map(|db| db.to_owned()),
+            pattern: pattern.map(|val| val.to_owned()),
         }));
 
         let rel_type = spark::relation::RelType::Catalog(spark::Catalog { cat_type });
@@ -113,14 +117,10 @@ impl Catalog {
 
     /// Returns a list of columns for the given tables/views in the specific database
     #[allow(non_snake_case)]
-    pub async fn listColumns(
-        &mut self,
-        tableName: String,
-        dbName: Option<String>,
-    ) -> Vec<RecordBatch> {
+    pub async fn listColumns(&mut self, tableName: &str, dbName: Option<&str>) -> Vec<RecordBatch> {
         let cat_type = Some(spark::catalog::CatType::ListColumns(spark::ListColumns {
-            table_name: tableName,
-            db_name: dbName,
+            table_name: tableName.to_owned(),
+            db_name: dbName.map(|val| val.to_owned()),
         }));
 
         let rel_type = spark::relation::RelType::Catalog(spark::Catalog { cat_type });
@@ -207,10 +207,7 @@ mod tests {
             .await
             .unwrap();
 
-        let value = spark
-            .catalog()
-            .listDatabases(Some("*rust".to_string()))
-            .await;
+        let value = spark.catalog().listDatabases(Some("*rust")).await;
 
         assert_eq!(4, value[0].num_columns());
         assert_eq!(1, value[0].num_rows());

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -45,6 +45,15 @@ where
     }
 }
 
+impl<const N: usize, T> ToVecExpr for [T; N]
+where
+    T: ToExpr,
+{
+    fn to_vec_expr(&self) -> Vec<spark::Expression> {
+        self.iter().map(|col| col.to_expr()).collect()
+    }
+}
+
 pub trait ToFilterExpr {
     fn to_filter_expr(&self) -> Option<spark::Expression>;
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -507,14 +507,14 @@ mod tests {
     async fn test_func_col_contains() {
         let spark = setup().await;
 
-        let paths = vec!["/opt/spark/examples/src/main/resources/people.csv".to_string()];
+        let path = ["/opt/spark/examples/src/main/resources/people.csv"];
 
         let mut df = spark
             .read()
             .format("csv")
             .option("header", "True")
             .option("delimiter", ";")
-            .load(paths);
+            .load(path);
 
         let row = df
             .filter(col("name").contains("e"))
@@ -536,14 +536,14 @@ mod tests {
     async fn test_func_col_isin() {
         let spark = setup().await;
 
-        let paths = vec!["/opt/spark/examples/src/main/resources/people.csv".to_string()];
+        let path = ["/opt/spark/examples/src/main/resources/people.csv"];
 
         let mut df = spark
             .read()
             .format("csv")
             .option("header", "True")
             .option("delimiter", ";")
-            .load(paths);
+            .load(path);
 
         let row = df
             .filter(col("name").isin(vec!["Jorge", "Bob"]))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,14 +154,14 @@ mod tests {
     async fn test_dataframe_read() {
         let spark = setup().await;
 
-        let paths = vec!["/opt/spark/examples/src/main/resources/people.csv".to_string()];
+        let path = ["/opt/spark/examples/src/main/resources/people.csv"];
 
         let mut df = spark
             .read()
             .format("csv")
             .option("header", "True")
             .option("delimiter", ";")
-            .load(paths);
+            .load(path);
 
         let rows = df
             .filter("age > 30")
@@ -197,7 +197,7 @@ mod tests {
             .read()
             .format("csv")
             .option("header", "true")
-            .load(vec![path.to_string()]);
+            .load([path]);
 
         let total: usize = df
             .select(vec![col("range_id")])


### PR DESCRIPTION
# Description

feat(generics): better generic args
- add better generic types to traits
- add new trait implementation for an array of expressions
- update example

## Example

Allow for statements like this in the `select` method.

```rust
df.select(["id", "value"])

// or like this

df.select([col("id"), col("value")])

// or like this too

df.select(vec![col("id"), col("value")])
```

All of which are translated to a vector expression.

Also there is better consistently for all function inputs. The default is `&str` for everything where a string input is needed. So all arguments that were `Vec<String>` are now `Vec<&str>`, etc.