### PR TITLE
feat(window): create Window & WindowSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ The following section outlines some of the larger functionality that are not yet
 
 - ![done] TLS authentication & Databricks compatability via the feature flag `feature = 'tls'`
 - ![open] StreamingQueryManager
-- ![open] Window and ~~Pivot~~ functions
 - ![open] UDFs or any type of functionality that takes a closure (foreach, foreachBatch, etc.)
 
 ### SparkSession
@@ -282,6 +281,7 @@ Spark [Column](https://spark.apache.org/docs/latest/api/python/reference/pyspark
 | like             | ![done] |                                                                              |
 | name             | ![done] |                                                                              |
 | otherwise        | ![open] |                                                                              |
+| over             | ![done] | Refer to **Window** for creating window specifications                       |
 | rlike            | ![done] |                                                                              |
 | startswith       | ![done] |                                                                              |
 | substr           | ![open] |                                                                              |
@@ -610,6 +610,25 @@ An array can be made like `lit([1_i16,2_i16,3_i16])` would result in an `ArrayTy
 | Array              | `slice` / `Vec`     | ![done] |
 | Map                |                     | ![open] |
 | Struct             |                     | ![open] |
+
+
+### Window & WindowSpec
+
+For ease of use it's recommended to use `Window` to create the `WindowSpec`.
+
+| Window                  | API     | Comment |
+|-------------------------|---------|---------|
+| currentRow              | ![done] |         |
+| orderBy                 | ![done] |         |
+| partitionBy             | ![done] |         |
+| rangeBetween            | ![done] |         |
+| rowsBetween             | ![done] |         |
+| unboundedFollowing      | ![done] |         |
+| unboundedPreceding      | ![done] |         |
+| WindowSpec.orderBy      | ![done] |         |
+| WindowSpec.partitionBy  | ![done] |         |
+| WindowSpec.rangeBetween | ![done] |         |
+| WindowSpec.rowsBetween  | ![done] |         |
 
 
 [open]: https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/IssueNeutral.svg

--- a/src/column.rs
+++ b/src/column.rs
@@ -7,6 +7,7 @@ use crate::spark;
 use crate::expressions::{ToExpr, ToLiteralExpr};
 use crate::functions::lit;
 use crate::utils::invoke_func;
+use crate::window::WindowSpec;
 
 /// # Column
 ///
@@ -323,6 +324,21 @@ impl Column {
     #[allow(non_snake_case)]
     pub fn isNaN(self) -> Column {
         invoke_func("isNaN", self)
+    }
+
+    pub fn over(self, window: WindowSpec) -> Column {
+        let window_expr = spark::expression::Window {
+            window_function: Some(Box::new(self.expression)),
+            partition_spec: window.partition_spec,
+            order_spec: window.order_spec,
+            frame_spec: window.frame,
+        };
+
+        let expression = spark::Expression {
+            expr_type: Some(spark::expression::ExprType::Window(Box::new(window_expr))),
+        };
+
+        Column::from(expression)
     }
 }
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -326,12 +326,28 @@ impl Column {
         invoke_func("isNaN", self)
     }
 
+    /// Defines a windowing column
+    /// # Arguments:
+    ///
+    /// * `window`: a [WindowSpec]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let window = Window::new()
+    ///     .partitionBy(col("name"))
+    ///     .orderBy([col("age")])
+    ///     .rangeBetween(Window::unboundedPreceding(), Window::currentRow());
+    ///
+    /// let df = df.withColumn("rank", rank().over(window.clone()))
+    ///     .withColumn("min", min("age").over(window));
+    /// ```
     pub fn over(self, window: WindowSpec) -> Column {
         let window_expr = spark::expression::Window {
             window_function: Some(Box::new(self.expression)),
             partition_spec: window.partition_spec,
             order_spec: window.order_spec,
-            frame_spec: window.frame,
+            frame_spec: window.frame_spec,
         };
 
         let expression = spark::Expression {

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -1831,20 +1831,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dataframe_sort() -> Result<(), SparkError> {
+    async fn test_df_sort() -> Result<(), SparkError> {
         let spark = setup().await;
 
-        let df = spark
-            .range(None, 100, 1, Some(1))
-            .sort(vec![col("id").desc()]);
+        let df = spark.range(None, 100, 1, Some(1));
 
-        let rows = df.limit(1).collect().await?;
+        let rows = df
+            .clone()
+            .sort([col("id").desc()])
+            .limit(1)
+            .collect()
+            .await?;
 
         let a: ArrayRef = Arc::new(Int64Array::from(vec![99]));
 
         let expected_batch = RecordBatch::try_from_iter(vec![("id", a)])?;
 
         assert_eq!(expected_batch, rows);
+
+        let rows = df.sort([col("id")]).limit(1).collect().await?;
+
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![0]));
+
+        let expected_batch = RecordBatch::try_from_iter(vec![("id", a)])?;
+
+        assert_eq!(expected_batch, rows);
+
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod storage;
 pub mod streaming;
 pub mod types;
 mod utils;
+pub mod window;
 
 pub use arrow;
 pub use dataframe::{DataFrame, DataFrameReader, DataFrameWriter};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,22 @@ pub fn invoke_func<T: ToVecExpr>(name: &str, args: T) -> Column {
     })
 }
 
+pub fn sort_order<I>(cols: I) -> Vec<spark::expression::SortOrder>
+where
+    I: IntoIterator<Item = Column>,
+{
+    cols.into_iter()
+        .map(|col| match col.clone().expression.expr_type.unwrap() {
+            spark::expression::ExprType::SortOrder(ord) => *ord,
+            _ => spark::expression::SortOrder {
+                child: Some(Box::new(col.expression)),
+                direction: 1,
+                null_ordering: 1,
+            },
+        })
+        .collect()
+}
+
 #[macro_export]
 macro_rules! generate_functions {
     (no_args: $($func_name:ident),*) => {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,4 @@
+#[allow(dead_code)]
+struct WindowSpec {}
+
+impl WindowSpec {}

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,230 @@
-#[allow(dead_code)]
-struct WindowSpec {}
+use crate::column::Column;
+use crate::expressions::ToVecExpr;
+use crate::functions::lit;
+use crate::spark;
+use crate::spark::expression::window;
+use crate::utils::sort_order;
 
-impl WindowSpec {}
+#[derive(Debug, Default, Clone)]
+pub struct WindowSpec {
+    pub partition_spec: Vec<spark::Expression>,
+    pub order_spec: Vec<spark::expression::SortOrder>,
+    pub frame: Option<Box<spark::expression::window::WindowFrame>>,
+}
+
+impl WindowSpec {
+    pub fn new(
+        partition_spec: Vec<spark::Expression>,
+        order_spec: Vec<spark::expression::SortOrder>,
+        frame: Option<Box<spark::expression::window::WindowFrame>>,
+    ) -> WindowSpec {
+        WindowSpec {
+            partition_spec,
+            order_spec,
+            frame,
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn partitionBy<I: ToVecExpr>(self, cols: I) -> WindowSpec {
+        WindowSpec::new(cols.to_vec_expr(), self.order_spec, self.frame)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn orderBy<I>(self, cols: I) -> WindowSpec
+    where
+        I: IntoIterator<Item = Column>,
+    {
+        let order = sort_order(cols);
+
+        WindowSpec::new(self.partition_spec, order, self.frame)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn rowsBetween(self, start: i64, end: i64) -> WindowSpec {
+        let frame = WindowSpec::window_frame(true, start, end);
+
+        WindowSpec::new(self.partition_spec, self.order_spec, frame)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn rangeBetween(self, start: i64, end: i64) -> WindowSpec {
+        let frame = WindowSpec::window_frame(false, start, end);
+
+        WindowSpec::new(self.partition_spec, self.order_spec, frame)
+    }
+
+    fn frame_boundary(value: i64) -> Option<Box<window::window_frame::FrameBoundary>> {
+        match value {
+            0 => {
+                let boundary = Some(window::window_frame::frame_boundary::Boundary::CurrentRow(
+                    true,
+                ));
+                Some(Box::new(window::window_frame::FrameBoundary { boundary }))
+            }
+            i64::MIN => {
+                let boundary = Some(window::window_frame::frame_boundary::Boundary::Unbounded(
+                    true,
+                ));
+                Some(Box::new(window::window_frame::FrameBoundary { boundary }))
+            }
+            _ => {
+                let value = lit(value).expression;
+
+                let boundary = Some(window::window_frame::frame_boundary::Boundary::Value(
+                    Box::new(value),
+                ));
+                Some(Box::new(window::window_frame::FrameBoundary { boundary }))
+            }
+        }
+    }
+
+    fn window_frame(row_frame: bool, start: i64, end: i64) -> Option<Box<window::WindowFrame>> {
+        let frame_type = match row_frame {
+            true => 1,
+            false => 2,
+        };
+
+        let lower = WindowSpec::frame_boundary(start);
+        let upper = WindowSpec::frame_boundary(end);
+
+        Some(Box::new(window::WindowFrame {
+            frame_type,
+            lower,
+            upper,
+        }))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Window {
+    spec: WindowSpec,
+}
+
+impl Window {
+    pub fn new() -> Self {
+        Window {
+            spec: WindowSpec::default(),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn currentRow() -> i64 {
+        0
+    }
+
+    #[allow(non_snake_case)]
+    pub fn unboundedFollowing() -> i64 {
+        i64::MAX
+    }
+
+    #[allow(non_snake_case)]
+    pub fn unboundedPreceding() -> i64 {
+        i64::MIN
+    }
+
+    #[allow(non_snake_case)]
+    pub fn partitionBy<I: ToVecExpr>(mut self, cols: I) -> WindowSpec {
+        self.spec = self.spec.partitionBy(cols);
+
+        self.spec
+    }
+
+    #[allow(non_snake_case)]
+    pub fn orderBy<I>(mut self, cols: I) -> WindowSpec
+    where
+        I: IntoIterator<Item = Column>,
+    {
+        self.spec = self.spec.orderBy(cols);
+
+        self.spec
+    }
+
+    #[allow(non_snake_case)]
+    pub fn rangeBetween(mut self, start: i64, end: i64) -> WindowSpec {
+        self.spec = self.spec.rangeBetween(start, end);
+
+        self.spec
+    }
+
+    #[allow(non_snake_case)]
+    pub fn rowsBetween(mut self, start: i64, end: i64) -> WindowSpec {
+        self.spec = self.spec.rowsBetween(start, end);
+
+        self.spec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use arrow::{
+        array::{ArrayRef, Int32Array, Int64Array, StringArray},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use std::sync::Arc;
+
+    use super::*;
+
+    use crate::errors::SparkError;
+    use crate::functions::*;
+    use crate::SparkSession;
+    use crate::SparkSessionBuilder;
+
+    async fn setup() -> SparkSession {
+        println!("SparkSession Setup");
+
+        let connection = "sc://127.0.0.1:15002/;user_id=rust_window";
+
+        SparkSessionBuilder::remote(connection)
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn mock_data() -> RecordBatch {
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![2, 5]));
+
+        RecordBatch::try_from_iter(vec![("name", name), ("age", age)]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_window_over() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+
+        let window = Window::new()
+            .partitionBy(col("name"))
+            .orderBy([col("age")])
+            .rowsBetween(Window::unboundedPreceding(), Window::currentRow());
+
+        let res = df
+            .withColumn("rank", rank().over(window.clone()))
+            .withColumn("min", min("age").over(window))
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![2, 5]));
+        let rank: ArrayRef = Arc::new(Int32Array::from(vec![1, 1]));
+        let min = age.clone();
+
+        let schema = Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+            Field::new("rank", DataType::Int32, false),
+            Field::new("min", DataType::Int64, true),
+        ]);
+
+        let expected = RecordBatch::try_new(Arc::new(schema), vec![name, age, rank, min])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,33 +1,39 @@
+//! Utility structs for defining a window over a DataFrame
+
 use crate::column::Column;
 use crate::expressions::ToVecExpr;
 use crate::functions::lit;
-use crate::spark;
-use crate::spark::expression::window;
 use crate::utils::sort_order;
 
+use crate::spark;
+use crate::spark::expression::window;
+
+/// A window specification that defines the partitioning, ordering, and frame boundaries.
+///
+/// **Recommended to create a WindowSpec using [Window] and not directly**
 #[derive(Debug, Default, Clone)]
 pub struct WindowSpec {
     pub partition_spec: Vec<spark::Expression>,
     pub order_spec: Vec<spark::expression::SortOrder>,
-    pub frame: Option<Box<spark::expression::window::WindowFrame>>,
+    pub frame_spec: Option<Box<window::WindowFrame>>,
 }
 
 impl WindowSpec {
     pub fn new(
         partition_spec: Vec<spark::Expression>,
         order_spec: Vec<spark::expression::SortOrder>,
-        frame: Option<Box<spark::expression::window::WindowFrame>>,
+        frame_spec: Option<Box<window::WindowFrame>>,
     ) -> WindowSpec {
         WindowSpec {
             partition_spec,
             order_spec,
-            frame,
+            frame_spec,
         }
     }
 
     #[allow(non_snake_case)]
     pub fn partitionBy<I: ToVecExpr>(self, cols: I) -> WindowSpec {
-        WindowSpec::new(cols.to_vec_expr(), self.order_spec, self.frame)
+        WindowSpec::new(cols.to_vec_expr(), self.order_spec, self.frame_spec)
     }
 
     #[allow(non_snake_case)]
@@ -35,23 +41,23 @@ impl WindowSpec {
     where
         I: IntoIterator<Item = Column>,
     {
-        let order = sort_order(cols);
+        let order_spec = sort_order(cols);
 
-        WindowSpec::new(self.partition_spec, order, self.frame)
+        WindowSpec::new(self.partition_spec, order_spec, self.frame_spec)
     }
 
     #[allow(non_snake_case)]
     pub fn rowsBetween(self, start: i64, end: i64) -> WindowSpec {
-        let frame = WindowSpec::window_frame(true, start, end);
+        let frame_spec = WindowSpec::window_frame(true, start, end);
 
-        WindowSpec::new(self.partition_spec, self.order_spec, frame)
+        WindowSpec::new(self.partition_spec, self.order_spec, frame_spec)
     }
 
     #[allow(non_snake_case)]
     pub fn rangeBetween(self, start: i64, end: i64) -> WindowSpec {
-        let frame = WindowSpec::window_frame(false, start, end);
+        let frame_spec = WindowSpec::window_frame(false, start, end);
 
-        WindowSpec::new(self.partition_spec, self.order_spec, frame)
+        WindowSpec::new(self.partition_spec, self.order_spec, frame_spec)
     }
 
     fn frame_boundary(value: i64) -> Option<Box<window::window_frame::FrameBoundary>> {
@@ -60,20 +66,26 @@ impl WindowSpec {
                 let boundary = Some(window::window_frame::frame_boundary::Boundary::CurrentRow(
                     true,
                 ));
+
                 Some(Box::new(window::window_frame::FrameBoundary { boundary }))
             }
             i64::MIN => {
                 let boundary = Some(window::window_frame::frame_boundary::Boundary::Unbounded(
                     true,
                 ));
+
                 Some(Box::new(window::window_frame::FrameBoundary { boundary }))
             }
             _ => {
-                let value = lit(value).expression;
+                // !TODO - I don't like casting this to i32
+                // however, the window boundary is expecting an INT and not a BIGINT
+                // i64 is a BIGINT (i.e. Long)
+                let value = lit(value as i32).expression;
 
                 let boundary = Some(window::window_frame::frame_boundary::Boundary::Value(
                     Box::new(value),
                 ));
+
                 Some(Box::new(window::window_frame::FrameBoundary { boundary }))
             }
         }
@@ -96,33 +108,39 @@ impl WindowSpec {
     }
 }
 
+/// Primary utility struct for defining window in DataFrames
 #[derive(Debug, Default, Clone)]
 pub struct Window {
     spec: WindowSpec,
 }
 
 impl Window {
+    /// Creates a new empty [WindowSpec]
     pub fn new() -> Self {
         Window {
             spec: WindowSpec::default(),
         }
     }
 
+    /// Returns 0
     #[allow(non_snake_case)]
     pub fn currentRow() -> i64 {
         0
     }
 
+    /// Returns [i64::MAX]
     #[allow(non_snake_case)]
     pub fn unboundedFollowing() -> i64 {
         i64::MAX
     }
 
+    /// Returns [i64::MIN]
     #[allow(non_snake_case)]
     pub fn unboundedPreceding() -> i64 {
         i64::MIN
     }
 
+    /// Creates a [WindowSpec] with the partitioning defined
     #[allow(non_snake_case)]
     pub fn partitionBy<I: ToVecExpr>(mut self, cols: I) -> WindowSpec {
         self.spec = self.spec.partitionBy(cols);
@@ -130,6 +148,7 @@ impl Window {
         self.spec
     }
 
+    /// Creates a [WindowSpec] with the ordering defined
     #[allow(non_snake_case)]
     pub fn orderBy<I>(mut self, cols: I) -> WindowSpec
     where
@@ -140,12 +159,51 @@ impl Window {
         self.spec
     }
 
+    /// Creates a [WindowSpec] with the frame boundaries defined, from start (inclusive) to end (inclusive).
+    ///
+    /// Both start and end are relative from the current row. For example, “0” means “current row”,
+    /// while “-1” means one off before the current row, and “5” means the five off after the current row.
+    ///
+    /// Recommended to use [Window::unboundedPreceding], [Window::unboundedFollowing], and [Window::currentRow]
+    /// to specify special boundary values, rather than using integral values directly.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let window = Window::new()
+    ///     .partitionBy(col("name"))
+    ///     .orderBy([col("age")])
+    ///     .rangeBetween(Window::unboundedPreceding(), Window::currentRow());
+    ///
+    /// let df = df.withColumn("rank", rank().over(window.clone()))
+    ///     .withColumn("min", min("age").over(window));
+    /// ```
     #[allow(non_snake_case)]
     pub fn rangeBetween(mut self, start: i64, end: i64) -> WindowSpec {
         self.spec = self.spec.rangeBetween(start, end);
 
         self.spec
     }
+
+    /// Creates a [WindowSpec] with the frame boundaries defined, from start (inclusive) to end (inclusive).
+    ///
+    /// Both start and end are relative from the current row. For example, “0” means “current row”,
+    /// while “-1” means one off before the current row, and “5” means the five off after the current row.
+    ///
+    /// Recommended to use [Window::unboundedPreceding], [Window::unboundedFollowing], and [Window::currentRow]
+    /// to specify special boundary values, rather than using integral values directly.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let window = Window::new()
+    ///     .partitionBy(col("name"))
+    ///     .orderBy([col("age")])
+    ///     .rowsBetween(Window::unboundedPreceding(), Window::currentRow());
+    ///
+    /// let df = df.withColumn("rank", rank().over(window.clone()))
+    ///     .withColumn("min", min("age").over(window));
+    /// ```
 
     #[allow(non_snake_case)]
     pub fn rowsBetween(mut self, start: i64, end: i64) -> WindowSpec {
@@ -184,17 +242,20 @@ mod tests {
     }
 
     fn mock_data() -> RecordBatch {
-        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob"]));
-        let age: ArrayRef = Arc::new(Int64Array::from(vec![2, 5]));
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 2, 1, 2, 3]));
+        let category: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "a", "b", "b", "b"]));
 
-        RecordBatch::try_from_iter(vec![("name", name), ("age", age)]).unwrap()
+        RecordBatch::try_from_iter(vec![("id", id), ("category", category)]).unwrap()
     }
 
     #[tokio::test]
     async fn test_window_over() -> Result<(), SparkError> {
         let spark = setup().await;
 
-        let data = mock_data();
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![2, 5]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name), ("age", age)])?;
 
         let df = spark.createDataFrame(&data)?;
 
@@ -222,6 +283,138 @@ mod tests {
         ]);
 
         let expected = RecordBatch::try_new(Arc::new(schema), vec![name, age, rank, min])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_window_orderby() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+
+        let window = Window::new()
+            .partitionBy(col("id"))
+            .orderBy([col("category")]);
+
+        let res = df
+            .withColumn("row_number", row_number().over(window))
+            .collect()
+            .await?;
+
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 1, 2, 2, 3]));
+        let category: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "b", "a", "b", "b"]));
+        let row_number: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 1, 2, 1]));
+
+        let expected = RecordBatch::try_from_iter(vec![
+            ("id", id),
+            ("category", category),
+            ("row_number", row_number),
+        ])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_window_partitionby() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+
+        let window = Window::new()
+            .partitionBy(col("category"))
+            .orderBy([col("id")]);
+
+        let res = df
+            .withColumn("row_number", row_number().over(window))
+            .collect()
+            .await?;
+
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 2, 1, 2, 3]));
+        let category: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "a", "b", "b", "b"]));
+        let row_number: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 1, 2, 3]));
+
+        let expected = RecordBatch::try_from_iter(vec![
+            ("id", id),
+            ("category", category),
+            ("row_number", row_number),
+        ])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_window_rangebetween() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+
+        let window = Window::new()
+            .partitionBy(col("category"))
+            .orderBy([col("id")])
+            .rangeBetween(Window::currentRow(), 1);
+
+        let res = df
+            .withColumn("sum", sum("id").over(window))
+            .sort([col("id"), col("category")])
+            .collect()
+            .await?;
+
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 1, 2, 2, 3]));
+        let category: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "b", "a", "b", "b"]));
+        let sum: ArrayRef = Arc::new(Int64Array::from(vec![4, 4, 3, 2, 5, 3]));
+
+        let expected = RecordBatch::try_from_iter_with_nullable(vec![
+            ("id", id, false),
+            ("category", category, false),
+            ("sum", sum, true),
+        ])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_window_rowsbetween() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+
+        let window = Window::new()
+            .partitionBy(col("category"))
+            .orderBy([col("id")])
+            .rowsBetween(Window::currentRow(), 1);
+
+        let res = df
+            .withColumn("sum", sum("id").over(window))
+            .sort([col("id"), col("category"), col("sum")])
+            .collect()
+            .await?;
+
+        let id: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 1, 2, 2, 3]));
+        let category: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "b", "a", "b", "b"]));
+        let sum: ArrayRef = Arc::new(Int64Array::from(vec![2, 3, 3, 2, 5, 3]));
+
+        let expected = RecordBatch::try_from_iter_with_nullable(vec![
+            ("id", id, false),
+            ("category", category, false),
+            ("sum", sum, true),
+        ])?;
 
         assert_eq!(expected, res);
 


### PR DESCRIPTION
# Description

feat(window): create Window & WindowSpec
- create two new structs for `Window` & `WindowSpec` based a similar implementation of the existing Spark API.
- add unit tests for coverage of specific Window methods
- add new `over` method onto `Column` and add unit test
- update Rust Docs and README for `Window

# Example Usage

```rust
let df = spark.createDataFrame(&data)?;

let window = Window::new()
    .partitionBy(col("category"))
    .orderBy([col("id")])
    .rowsBetween(Window::currentRow(), 1);

let df = df
    .withColumn("sum", sum("id").over(window))
    .sort([col("id"), col("category"), col("sum")]);
```
