### PR TITLE
feat: client improvements & flaky tests

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -517,26 +517,6 @@ mod tests {
 
         ()
     }
-    #[tokio::test]
-    async fn test_list_databases() -> Result<(), SparkError> {
-        let spark = setup().await;
-
-        let res = spark.clone().catalog().listDatabases(None).await?;
-
-        assert_eq!(4, res.num_columns());
-        assert!(res.num_rows() >= 1);
-
-        let res = spark
-            .clone()
-            .catalog()
-            .listDatabases(Some("default"))
-            .await?;
-
-        assert_eq!(4, res.num_columns());
-        assert_eq!(1, res.num_rows());
-
-        Ok(())
-    }
 
     #[tokio::test]
     async fn test_get_database() -> Result<(), SparkError> {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -489,14 +489,18 @@ mod tests {
     async fn test_set_current_database() -> Result<(), SparkError> {
         let spark = setup().await;
 
+        spark.clone().sql("CREATE SCHEMA current_db").await?;
+
         spark
             .clone()
-            .sql("CREATE SCHEMA IF NOT EXISTS spark_rust_db")
+            .catalog()
+            .setCurrentDatabase("current_db")
             .await?;
 
-        spark.catalog().setCurrentDatabase("spark_rust_db").await?;
-
         assert!(true);
+
+        spark.clone().sql("DROP SCHEMA current_db").await?;
+
         Ok(())
     }
 
@@ -517,18 +521,16 @@ mod tests {
     async fn test_list_databases() -> Result<(), SparkError> {
         let spark = setup().await;
 
-        spark
-            .clone()
-            .sql("CREATE SCHEMA IF NOT EXISTS spark_rust")
-            .await
-            .unwrap();
-
         let res = spark.clone().catalog().listDatabases(None).await?;
 
         assert_eq!(4, res.num_columns());
-        assert_eq!(2, res.num_rows());
+        assert!(res.num_rows() >= 1);
 
-        let res = spark.catalog().listDatabases(Some("*rust")).await?;
+        let res = spark
+            .clone()
+            .catalog()
+            .listDatabases(Some("default"))
+            .await?;
 
         assert_eq!(4, res.num_columns());
         assert_eq!(1, res.num_rows());
@@ -540,14 +542,14 @@ mod tests {
     async fn test_get_database() -> Result<(), SparkError> {
         let spark = setup().await;
 
-        spark
-            .clone()
-            .sql("CREATE SCHEMA IF NOT EXISTS spark_rust")
-            .await?;
+        spark.clone().sql("CREATE SCHEMA get_db").await?;
 
-        let res = spark.catalog().getDatabase("spark_rust").await?;
+        let res = spark.clone().catalog().getDatabase("get_db").await?;
 
         assert_eq!(res.num_rows(), 1);
+
+        spark.clone().sql("DROP SCHEMA get_db").await?;
+
         Ok(())
     }
 
@@ -633,30 +635,28 @@ mod tests {
     async fn test_cache_table() -> Result<(), SparkError> {
         let spark = setup().await;
 
-        spark.clone().sql("DROP TABLE IF EXISTS tmp_table").await?;
-
         spark
             .clone()
-            .sql("CREATE TABLE tmp_table (name STRING, age INT) using parquet")
+            .sql("CREATE TABLE cache_table (name STRING, age INT) using parquet")
             .await?;
 
         spark
             .clone()
             .catalog()
-            .cacheTable("tmp_table", None)
+            .cacheTable("cache_table", None)
             .await?;
 
-        let res = spark.clone().catalog().isCached("tmp_table").await?;
+        let res = spark.clone().catalog().isCached("cache_table").await?;
 
         assert!(res);
 
-        spark.clone().catalog().uncacheTable("tmp_table").await?;
+        spark.clone().catalog().uncacheTable("cache_table").await?;
 
-        let res = spark.clone().catalog().isCached("tmp_table").await?;
+        let res = spark.clone().catalog().isCached("cache_table").await?;
 
         assert!(!res);
 
-        spark.sql("DROP TABLE IF EXISTS tmp_table").await?;
+        spark.sql("DROP TABLE cache_table").await?;
         Ok(())
     }
 }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -376,12 +376,8 @@ impl DataFrame {
                 explain_mode: explain_mode.into(),
             });
 
-        let explain = self
-            .spark_session
-            .client()
-            .analyze(analyze)
-            .await?
-            .explain()?;
+        let mut client = self.spark_session.client();
+        let explain = client.analyze(analyze).await?.explain()?;
 
         println!("{}", explain);
 
@@ -446,11 +442,9 @@ impl DataFrame {
             },
         );
 
-        self.spark_session
-            .client()
-            .analyze(input_files)
-            .await?
-            .input_files()
+        let mut client = self.spark_session.client();
+
+        client.analyze(input_files).await?.input_files()
     }
 
     /// Return a new DataFrame containing rows only in both this DataFrame and another DataFrame.
@@ -488,11 +482,9 @@ impl DataFrame {
             },
         );
 
-        self.spark_session
-            .client()
-            .analyze(is_streaming)
-            .await?
-            .is_streaming()
+        let mut client = self.spark_session.client();
+
+        client.analyze(is_streaming).await?.is_streaming()
     }
 
     /// Joins with another DataFrame, using the given join expression.
@@ -563,12 +555,9 @@ impl DataFrame {
                 storage_level: Some(storage_level.into()),
             });
 
-        self.spark_session
-            .clone()
-            .client()
-            .analyze(analyze)
-            .await
-            .unwrap();
+        let mut client = self.spark_session.clone().client();
+
+        client.analyze(analyze).await.unwrap();
 
         DataFrame::new(self.spark_session, self.logical_plan)
     }
@@ -582,14 +571,10 @@ impl DataFrame {
                 level,
             },
         );
-        let tree = self
-            .spark_session
-            .client()
-            .analyze(tree_string)
-            .await?
-            .tree_string()?;
 
-        Ok(tree)
+        let mut client = self.spark_session.client();
+
+        client.analyze(tree_string).await?.tree_string()
     }
 
     /// Returns a new [DataFrame] partitioned by the given partition number and shuffle option
@@ -624,14 +609,10 @@ impl DataFrame {
                 other_plan,
             },
         );
-        let same_semantics = self
-            .spark_session
-            .client()
-            .analyze(same_semantics)
-            .await?
-            .same_semantics()?;
 
-        Ok(same_semantics)
+        let mut client = self.spark_session.client();
+
+        client.analyze(same_semantics).await?.same_semantics()
     }
 
     /// Returns a sampled subset of this [DataFrame]
@@ -659,14 +640,9 @@ impl DataFrame {
                 plan: Some(plan),
             });
 
-        let data_type = self
-            .spark_session
-            .client()
-            .analyze(schema)
-            .await?
-            .schema()?;
+        let mut client = self.spark_session.client();
 
-        Ok(data_type)
+        client.analyze(schema).await?.schema()
     }
 
     /// Projects a set of expressions and returns a new [DataFrame]
@@ -711,14 +687,9 @@ impl DataFrame {
             spark::analyze_plan_request::SemanticHash { plan: Some(plan) },
         );
 
-        let semantic_hash = self
-            .spark_session
-            .client()
-            .analyze(semantic_hash)
-            .await?
-            .semantic_hash()?;
+        let mut client = self.spark_session.client();
 
-        Ok(semantic_hash)
+        client.analyze(semantic_hash).await?.semantic_hash()
     }
 
     /// Prints the first `n` rows to the console
@@ -769,14 +740,10 @@ impl DataFrame {
             },
         );
 
-        let storage = self
-            .spark_session
-            .client()
-            .analyze(storage_level)
-            .await?
-            .get_storage_level()?;
+        let mut client = self.spark_session.client();
+        let storage = client.analyze(storage_level).await?.get_storage_level();
 
-        Ok(storage.into())
+        Ok(storage?.into())
     }
 
     pub fn subtract(self, other: DataFrame) -> DataFrame {
@@ -851,12 +818,9 @@ impl DataFrame {
             },
         );
 
-        self.spark_session
-            .clone()
-            .client()
-            .analyze(unpersist)
-            .await
-            .unwrap();
+        let mut client = self.spark_session.clone().client();
+
+        client.analyze(unpersist).await.unwrap();
 
         DataFrame::new(self.spark_session, self.logical_plan)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ pub enum SparkError {
     AnalysisException(String),
     IoError(String, std::io::Error),
     ArrowError(ArrowError),
+    InvalidConnectionUrl(String),
 }
 
 impl SparkError {
@@ -75,6 +76,7 @@ impl Display for SparkError {
             SparkError::IoError(desc, _) => write!(f, "Io error: {desc}"),
             SparkError::ArrowError(desc) => write!(f, "Apache Arrow error: {desc}"),
             SparkError::NotYetImplemented(source) => write!(f, "Not yet implemented: {source}"),
+            SparkError::InvalidConnectionUrl(val) => write!(f, "Invalid URL error: {val}"),
         }
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,8 +1,7 @@
 //! A DataFrame created with an aggregate statement
 
-use crate::column::Column;
 use crate::dataframe::DataFrame;
-use crate::expressions::{ToLiteral, ToVecExpr};
+use crate::expressions::{ToExpr, ToLiteral, ToVecExpr};
 use crate::plan::LogicalPlanBuilder;
 
 use crate::functions::lit;
@@ -16,7 +15,7 @@ pub struct GroupedData {
     df: DataFrame,
     group_type: GroupType,
     grouping_cols: Vec<spark::Expression>,
-    pivot_col: Option<Column>,
+    pivot_col: Option<spark::Expression>,
     pivot_vals: Option<Vec<spark::expression::Literal>>,
 }
 
@@ -25,7 +24,7 @@ impl GroupedData {
         df: DataFrame,
         group_type: GroupType,
         grouping_cols: Vec<spark::Expression>,
-        pivot_col: Option<Column>,
+        pivot_col: Option<spark::Expression>,
         pivot_vals: Option<Vec<spark::expression::Literal>>,
     ) -> GroupedData {
         Self {
@@ -84,7 +83,7 @@ impl GroupedData {
             self.df,
             GroupType::Pivot,
             self.grouping_cols,
-            Some(Column::from(col)),
+            Some(col.to_expr()),
             pivot_vals,
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,6 @@ pub mod types;
 mod utils;
 pub mod window;
 
-pub use arrow;
 pub use dataframe::{DataFrame, DataFrameReader, DataFrameWriter};
 pub use session::{SparkSession, SparkSessionBuilder};
 

--- a/src/readwriter.rs
+++ b/src/readwriter.rs
@@ -353,6 +353,7 @@ mod tests {
         let path = "/opt/spark/examples/src/main/rust/employees/";
 
         df.write()
+            .mode(SaveMode::Overwrite)
             .format("csv")
             .option("header", "true")
             .save(path)


### PR DESCRIPTION
# Description

feat: client improvements & flaky tests
- Update client mod to be more reusable
- Leverage environment variables for `SPARK_REMOTE` and `USER` 
- Move `SparkSessionBuilder` to `session` module
- Change `mutex` to `rwlock` when creating the client object
- Fix flaky tests
- Remove `arrow` as a re-export
