### PR TITLE
feat: initial implementation of DataframeWriterV2

### DIFF
--- a/core/src/dataframe.rs
+++ b/core/src/dataframe.rs
@@ -5,7 +5,7 @@ use crate::errors::SparkError;
 use crate::expressions::{ToExpr, ToFilterExpr, ToVecExpr};
 use crate::group::GroupedData;
 use crate::plan::LogicalPlanBuilder;
-pub use crate::readwriter::{DataFrameReader, DataFrameWriter};
+pub use crate::readwriter::{DataFrameReader, DataFrameWriter, DataFrameWriterV2};
 use crate::session::SparkSession;
 use crate::spark;
 use crate::storage;
@@ -1025,6 +1025,10 @@ impl DataFrame {
     /// Returns a [DataFrameWriter] struct based on the current [DataFrame]
     pub fn write(self) -> DataFrameWriter {
         DataFrameWriter::new(self)
+    }
+
+    pub fn writeTo<T: ToString>(self, table: T) -> DataFrameWriterV2 {
+        DataFrameWriterV2::new(self, table)
     }
 
     /// Interface for [DataStreamWriter] to save the content of the streaming DataFrame out

--- a/core/src/dataframe.rs
+++ b/core/src/dataframe.rs
@@ -1027,7 +1027,8 @@ impl DataFrame {
         DataFrameWriter::new(self)
     }
 
-    pub fn writeTo<T: ToString>(self, table: T) -> DataFrameWriterV2 {
+    #[allow(non_snake_case)]
+    pub fn writeTo(self, table: &str) -> DataFrameWriterV2 {
         DataFrameWriterV2::new(self, table)
     }
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -11,6 +11,7 @@ use crate::DataFrame;
 use spark::write_operation::SaveMode;
 use spark::write_operation_v2::Mode;
 use spark::Expression;
+use crate::expressions::ToVecExpr;
 
 /// DataFrameReader represents the entrypoint to create a DataFrame
 /// from a specific file format.
@@ -350,8 +351,8 @@ impl DataFrameWriterV2 {
     }
 
     #[allow(non_snake_case)]
-    pub fn partitionBy(mut self, columns: Vec<Expression>) -> Self {
-        self.partitioning = columns;
+    pub fn partitionBy<T: ToVecExpr>(mut self, columns: T) -> Self {
+        self.partitioning = columns.to_vec_expr();
         self
     }
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -355,29 +355,29 @@ impl DataFrameWriterV2 {
         self
     }
 
-    pub async fn create(mut self) -> Result<(), SparkError> {
+    pub async fn create(self) -> Result<(), SparkError> {
         self.execute_write(Mode::Create).await
     }
 
-    pub async fn replace(mut self) -> Result<(), SparkError> {
+    pub async fn replace(self) -> Result<(), SparkError> {
         self.execute_write(Mode::Replace).await
     }
 
     #[allow(non_snake_case)]
-    pub async fn createOrReplace(mut self) -> Result<(), SparkError> {
+    pub async fn createOrReplace(self) -> Result<(), SparkError> {
         self.execute_write(Mode::CreateOrReplace).await
     }
 
-    pub async fn append(mut self) -> Result<(), SparkError> {
+    pub async fn append(self) -> Result<(), SparkError> {
         self.execute_write(Mode::Append).await
     }
 
-    pub async fn overwrite(mut self) -> Result<(), SparkError> {
+    pub async fn overwrite(self) -> Result<(), SparkError> {
         self.execute_write(Mode::Overwrite).await
     }
 
     #[allow(non_snake_case)]
-    pub async fn overwritePartitions(mut self) -> Result<(), SparkError> {
+    pub async fn overwritePartitions(self) -> Result<(), SparkError> {
         self.execute_write(Mode::OverwritePartitions).await
     }
 
@@ -386,7 +386,7 @@ impl DataFrameWriterV2 {
             input: Some(self.dataframe.plan.relation()),
             table_name: self.table,
             provider: self.provider,
-            partitioning_columns: self.partitioning.unwrap_or_default(),
+            partitioning_columns: self.partitioning,
             options: self.options,
             table_properties: self.properties,
             mode: 0,

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -315,7 +315,7 @@ pub struct DataFrameWriterV2 {
 }
 
 impl DataFrameWriterV2 {
-    pub fn new<T: ToString>(dataframe: DataFrame, table: T) -> Self {
+    pub fn new(dataframe: DataFrame, table: &str) -> Self {
         Self {
             dataframe,
             table: table.to_string(),
@@ -327,23 +327,23 @@ impl DataFrameWriterV2 {
         }
     }
 
-    pub fn using<P: ToString>(mut self, provider: P) -> Self {
+    pub fn using(mut self, provider: &str) -> Self {
         self.provider.replace(provider.to_string());
         self
     }
 
-    pub fn option<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
+    pub fn option(mut self, key: &str, value: &str) -> Self {
         self.options.insert(key.to_string(), value.to_string());
         self
     }
 
     pub fn options(mut self, provider: HashMap<String, String>) -> Self {
-        self.options.extend(provider.into_iter());
+        self.options.extend(provider);
         self
     }
 
     #[allow(non_snake_case)]
-    pub fn tableProperty<P: ToString, V: ToString>(mut self, property: P, value: V) -> Self {
+    pub fn tableProperty(mut self, property: &str, value: &str) -> Self {
         self.properties
             .insert(property.to_string(), value.to_string());
         self

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -8,10 +8,10 @@ use crate::session::SparkSession;
 use crate::spark;
 use crate::DataFrame;
 
+use crate::expressions::ToVecExpr;
 use spark::write_operation::SaveMode;
 use spark::write_operation_v2::Mode;
 use spark::Expression;
-use crate::expressions::ToVecExpr;
 
 /// DataFrameReader represents the entrypoint to create a DataFrame
 /// from a specific file format.


### PR DESCRIPTION
# Description
Initial impl of DataframeWriterV2

# Related Issue(s)


# Documentation

Based off 
https://github.com/apache/spark/blob/master/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
and
https://github.com/apache/spark/blob/57b207774382e3a35345518ede5cfc028885f90b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala 
