### PR TITLE
feat(dataframe): implement transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Spark [DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pysp
 | toJSON                        | ![open] |                                                            |
 | toLocalIterator               | ![open] |                                                            |
 | toPandas                      | ![open] | TBD on this exact implementation. Might be toPolars        |
-| transform                     | ![open] |                                                            |
+| transform                     | ![done] |                                                            |
 | union                         | ![done] |                                                            |
 | unionAll                      | ![done] |                                                            |
 | unionByName                   | ![done] |                                                            |


### PR DESCRIPTION
# Description
feat(dataframe): implement transform
   - add method for `transform` that accepts a closure where the first param is a dataframe

### Example Usage

This uses closures and differs slightly from the pyspark implementation. Pyspark allows for positional or kwargs args. It's a little tricky to implement that specific option in rust. So I opted for just a closure that accepts and returns a `DataFrame` and it's on the user to provide any additional args as part of the captured scope of the closure. 

```rust
let df = spark.range(None, 1, 1, None);

// closure with a captured value from the immediate scope
// results in the `lit` val being 100
let val: i64 = 100;
let func = |df: DataFrame| -> DataFrame { df.withColumn("new_col", lit(val)).select("new_col") };

// a dataframe with a column `new_col` and a value of `100`
let df = df.transform(func);

```