### PR TITLE
bug(tls): incorrect scheme for default endpoint

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -64,7 +64,13 @@ impl ChannelBuilder {
     }
 
     pub fn endpoint(&self) -> String {
-        format!("https://{}:{}", self.host, self.port)
+        let scheme = if cfg!(feature = "tls") {
+            "https"
+        } else {
+            "http"
+        };
+
+        format!("{}://{}:{}", scheme, self.host, self.port)
     }
 
     pub fn token(&self) -> Option<String> {
@@ -665,7 +671,7 @@ mod tests {
 
     #[test]
     fn test_channel_builder_default() {
-        let expected_url = "https://localhost:15002".to_string();
+        let expected_url = "http://localhost:15002".to_string();
 
         let cb = ChannelBuilder::default();
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -241,7 +241,7 @@ mod tests {
         let ssbuilder = SparkSessionBuilder::remote(connection);
 
         assert_eq!(
-            "https://myhost.com:443".to_string(),
+            "http://myhost.com:443".to_string(),
             ssbuilder.channel_builder.endpoint()
         );
         assert_eq!(


### PR DESCRIPTION
# Description

bug(tls): incorrect scheme for default endpoint
- needs to be `https` for only when using the `tls` feature

# Related Issue(s)
<!---
For example:

- closes #106
--->

- closes #38 