### PR TITLE
feat(data types): implement data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,10 +725,34 @@ Only a few of the functions are covered by unit tests.
 | zip_with                    | ![open] |         |
 
 
-### Schema
+### Data Types
 
-Spark schema objects have not yet been translated into rust objects.
+Data types are used for creating schemas and for casting columns to specific types
 
+| Column                | API     | Comment           |
+|-----------------------|---------|-------------------|
+| ArrayType             | ![done] |                   |
+| BinaryType            | ![done] |                   |
+| BooleanType           | ![done] |                   |
+| ByteType              | ![done] |                   |
+| DateType              | ![done] |                   |
+| DecimalType           | ![done] |                   |
+| DoubleType            | ![done] |                   |
+| FloatType             | ![done] |                   |
+| IntegerType           | ![done] |                   |
+| LongType              | ![done] |                   |
+| MapType               | ![done] |                   |
+| NullType              | ![done] |                   |
+| ShortType             | ![done] |                   |
+| StringType            | ![done] |                   |
+| CharType              | ![done] |                   |
+| VarcharType           | ![done] |                   |
+| StructField           | ![done] |                   |
+| StructType            | ![done] |                   |
+| TimestampType         | ![done] |                   |
+| TimestampNTZType      | ![done] |                   |
+| DayTimeIntervalType   | ![done] |                   |
+| YearMonthIntervalType | ![done] |                   |
 
 ### Literal Types
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The following section outlines some of the larger functionality that are not yet
 |options           |![done]   |                                       |
 |orc               |![open]   |                                       |
 |parquet           |![open]   |                                       |
-|schema            |![open]   |                                       |
+|schema            |![done]   |                                       |
 |table             |![done]   |                                       |
 |text              |![open]   |                                       |
 

--- a/core/src/column.rs
+++ b/core/src/column.rs
@@ -6,6 +6,7 @@ use crate::spark;
 
 use crate::expressions::{ToExpr, ToLiteralExpr};
 use crate::functions::invoke_func;
+use crate::types::DataType;
 use crate::window::WindowSpec;
 
 /// # Column
@@ -40,43 +41,28 @@ pub struct Column {
     pub expression: spark::Expression,
 }
 
-impl From<spark::Expression> for Column {
-    /// Used for creating columns from a [spark::Expression]
-    fn from(expression: spark::Expression) -> Self {
-        Self { expression }
+/// Trait used to cast columns to specific [DataTypes]
+///
+/// Either with a String or a [DataType]
+pub trait CastToDataType {
+    fn cast_to_data_type(&self) -> spark::expression::cast::CastToType;
+}
+
+impl CastToDataType for DataType {
+    fn cast_to_data_type(&self) -> spark::expression::cast::CastToType {
+        spark::expression::cast::CastToType::Type(self.clone().into())
     }
 }
 
-impl From<&str> for Column {
-    /// `&str` values containing a `*` will be created as an unresolved star expression
-    /// Otherwise, the value is created as an unresolved attribute
-    fn from(value: &str) -> Self {
-        let expression = match value {
-            "*" => spark::Expression {
-                expr_type: Some(spark::expression::ExprType::UnresolvedStar(
-                    spark::expression::UnresolvedStar {
-                        unparsed_target: None,
-                    },
-                )),
-            },
-            value if value.ends_with(".*") => spark::Expression {
-                expr_type: Some(spark::expression::ExprType::UnresolvedStar(
-                    spark::expression::UnresolvedStar {
-                        unparsed_target: Some(value.to_string()),
-                    },
-                )),
-            },
-            _ => spark::Expression {
-                expr_type: Some(spark::expression::ExprType::UnresolvedAttribute(
-                    spark::expression::UnresolvedAttribute {
-                        unparsed_identifier: value.to_string(),
-                        plan_id: None,
-                    },
-                )),
-            },
-        };
+impl CastToDataType for String {
+    fn cast_to_data_type(&self) -> spark::expression::cast::CastToType {
+        spark::expression::cast::CastToType::TypeStr(self.to_string())
+    }
+}
 
-        Column::from(expression)
+impl CastToDataType for &str {
+    fn cast_to_data_type(&self) -> spark::expression::cast::CastToType {
+        spark::expression::cast::CastToType::TypeStr(self.to_string())
     }
 }
 
@@ -236,25 +222,31 @@ impl Column {
         )
     }
 
-    /// Casts the column into the Spark type represented as a `&str`
+    /// Casts the column into the Spark DataType
     ///
     /// # Arguments:
     ///
-    /// * `to_type` is the string representation of the datatype
+    /// * `to_type` is a string or [DataType] of the target type
     ///
     /// # Example:
     /// ```rust
+    /// use crate::types::DataType;
+    ///
     /// let df = df.select([
     ///       col("age").cast("int"),
     ///       col("name").cast("string")
     ///     ])
+    ///
+    /// // Using DataTypes
+    /// let df = df.select([
+    ///       col("age").cast(DataType::Integer),
+    ///       col("name").cast(DataType::String)
+    ///     ])
     /// ```
-    pub fn cast(self, to_type: &str) -> Column {
-        let type_str = spark::expression::cast::CastToType::TypeStr(to_type.to_string());
-
+    pub fn cast<T: CastToDataType>(self, to_type: T) -> Column {
         let cast = spark::expression::Cast {
             expr: Some(Box::new(self.expression)),
-            cast_to_type: Some(type_str),
+            cast_to_type: Some(to_type.cast_to_data_type()),
         };
 
         let expression = spark::Expression {
@@ -385,6 +377,46 @@ impl Column {
 
         let expression = spark::Expression {
             expr_type: Some(spark::expression::ExprType::Window(Box::new(window_expr))),
+        };
+
+        Column::from(expression)
+    }
+}
+
+impl From<spark::Expression> for Column {
+    /// Used for creating columns from a [spark::Expression]
+    fn from(expression: spark::Expression) -> Self {
+        Self { expression }
+    }
+}
+
+impl From<&str> for Column {
+    /// `&str` values containing a `*` will be created as an unresolved star expression
+    /// Otherwise, the value is created as an unresolved attribute
+    fn from(value: &str) -> Self {
+        let expression = match value {
+            "*" => spark::Expression {
+                expr_type: Some(spark::expression::ExprType::UnresolvedStar(
+                    spark::expression::UnresolvedStar {
+                        unparsed_target: None,
+                    },
+                )),
+            },
+            value if value.ends_with(".*") => spark::Expression {
+                expr_type: Some(spark::expression::ExprType::UnresolvedStar(
+                    spark::expression::UnresolvedStar {
+                        unparsed_target: Some(value.to_string()),
+                    },
+                )),
+            },
+            _ => spark::Expression {
+                expr_type: Some(spark::expression::ExprType::UnresolvedAttribute(
+                    spark::expression::UnresolvedAttribute {
+                        unparsed_identifier: value.to_string(),
+                        plan_id: None,
+                    },
+                )),
+            },
         };
 
         Column::from(expression)

--- a/core/src/dataframe.rs
+++ b/core/src/dataframe.rs
@@ -5,17 +5,18 @@ use crate::errors::SparkError;
 use crate::expressions::{ToExpr, ToFilterExpr, ToVecExpr};
 use crate::group::GroupedData;
 use crate::plan::LogicalPlanBuilder;
-pub use crate::readwriter::{DataFrameReader, DataFrameWriter, DataFrameWriterV2};
 use crate::session::SparkSession;
-use crate::spark;
 use crate::storage;
+
+pub use crate::readwriter::{DataFrameReader, DataFrameWriter, DataFrameWriterV2};
 pub use crate::streaming::{DataStreamReader, DataStreamWriter, OutputMode, StreamingQuery};
+
+use crate::spark;
 pub use spark::aggregate::GroupType;
 pub use spark::analyze_plan_request::explain::ExplainMode;
 pub use spark::join::JoinType;
-pub use spark::write_operation::SaveMode;
-
 use spark::relation::RelType;
+pub use spark::write_operation::SaveMode;
 
 use arrow::array::PrimitiveArray;
 use arrow::datatypes::{DataType, Float64Type};

--- a/core/src/expressions.rs
+++ b/core/src/expressions.rs
@@ -19,7 +19,6 @@
 use crate::spark;
 
 use crate::column::Column;
-use crate::types::ToDataType;
 
 /// Translate string values into a `spark::Expression`
 pub trait ToExpr {
@@ -232,19 +231,19 @@ impl ToLiteralExpr for Column {
 /// Create a Spark ArrayType from a vec
 impl<T> ToLiteralExpr for Vec<T>
 where
-    T: ToDataType + ToLiteral,
+    T: ToLiteral + Clone,
+    spark::DataType: From<T>,
 {
     fn to_literal_expr(&self) -> spark::Expression {
-        let kind = self
-            .first()
-            .expect("Array can not be empty")
-            .to_proto_type();
+        let element_type = Some(spark::DataType::from(
+            self.first().expect("Array can not be empty").clone(),
+        ));
 
-        let literal_vec = self.iter().map(|val| val.to_literal()).collect();
+        let elements = self.iter().map(|val| val.to_literal()).collect();
 
         let array_type = spark::expression::literal::Array {
-            element_type: Some(kind),
-            elements: literal_vec,
+            element_type,
+            elements,
         };
 
         spark::Expression {
@@ -260,19 +259,19 @@ where
 /// Create a Spark ArrayType from a slice
 impl<const N: usize, T> ToLiteralExpr for [T; N]
 where
-    T: ToDataType + ToLiteral,
+    T: ToLiteral + Clone,
+    spark::DataType: From<T>,
 {
     fn to_literal_expr(&self) -> spark::Expression {
-        let kind = self
-            .first()
-            .expect("Array can not be empty")
-            .to_proto_type();
+        let element_type = Some(spark::DataType::from(
+            self.first().expect("Array can not be empty").clone(),
+        ));
 
-        let literal_vec = self.iter().map(|val| val.to_literal()).collect();
+        let elements = self.iter().map(|val| val.to_literal()).collect();
 
         let array_type = spark::expression::literal::Array {
-            element_type: Some(kind),
-            elements: literal_vec,
+            element_type,
+            elements,
         };
 
         spark::Expression {

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -547,7 +547,7 @@ mod tests {
         let df = spark
             .clone()
             .range(None, 1, 1, Some(1))
-            .select(lit([1, 2, 3]));
+            .select(lit(vec![1, 2, 3]));
 
         let row = df.collect().await?;
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,15 +1,551 @@
 //! Rust Types to Spark Types
+#![allow(dead_code)]
 
 use crate::spark;
 
-pub trait ToDataType {
-    fn to_proto_type(&self) -> spark::DataType;
+/// Represents basic methods for a [SparkDataType]
+pub trait SparkDataType {
+    /// JSON representation of the object
+    fn json(&self) -> String;
+
+    fn type_name(&self) -> String {
+        self.as_str_name()
+    }
+
+    fn json_value(&self) -> String {
+        self.as_str_name()
+    }
+
+    fn as_str_name(&self) -> String {
+        self.json()
+    }
 }
 
-macro_rules! impl_to_data_type {
+/// Representation of a Spark StructType
+///
+/// Used to create the a schema with other [DataType]
+///
+/// # Example:
+///
+/// ```
+/// let schema = StructType::new(vec![
+///        StructField {
+///             name: "name",
+///             data_type: DataType::String,
+///             nullable: false,
+///             metadata: None,
+///         },
+///         StructField {
+///             name: "age",
+///             data_type: DataType::Short,
+///             nullable: true,
+///             metadata: None,
+///         },
+///     ]);
+/// ```
+///
+/// Complex types are also supported. The example below creates an [DataType::Array]
+/// that contains a two [StructField].
+///
+/// # Example:
+///
+/// ```
+/// let complex_schema = DataType::Array {
+///         element_type: Box::new(DataType::Struct(Box::new(StructType::new(vec![
+///             StructField {
+///                 name: "col5",
+///                 data_type: DataType::String,
+///                 nullable: true,
+///                 metadata: None,
+///             },
+///             StructField {
+///                 name: "col6",
+///                 data_type: DataType::Char(200),
+///                 nullable: true,
+///                 metadata: None,
+///             },
+///         ])))),
+///         contains_null: true,
+///     };
+/// ```
+#[derive(Clone, Debug)]
+pub struct StructType {
+    fields: Vec<StructField>,
+}
+
+impl StructType {
+    /// Create an empty StructType
+    pub fn empty() -> Self {
+        StructType { fields: vec![] }
+    }
+
+    /// Create a new StructType from a vector of [StructField]
+    pub fn new(fields: Vec<StructField>) -> Self {
+        StructType { fields }
+    }
+
+    pub fn fields(&self) -> Vec<StructField> {
+        self.fields.clone()
+    }
+
+    /// Append a new field onto the exist fields
+    pub fn append(mut self, field: StructField) -> Self {
+        self.fields.push(field);
+        self
+    }
+}
+
+impl From<StructType> for spark::DataType {
+    fn from(value: StructType) -> spark::DataType {
+        let fields: Vec<spark::data_type::StructField> = value
+            .fields
+            .iter()
+            .map(|f| f.clone().to_proto_type())
+            .collect();
+
+        let struct_type = spark::data_type::Struct {
+            fields,
+            type_variation_reference: 0,
+        };
+
+        spark::DataType {
+            kind: Some(spark::data_type::Kind::Struct(struct_type)),
+        }
+    }
+}
+
+impl SparkDataType for StructType {
+    fn type_name(&self) -> String {
+        String::from("struct")
+    }
+
+    fn as_str_name(&self) -> String {
+        self.type_name()
+    }
+
+    fn json(&self) -> String {
+        let fields: String = self
+            .fields
+            .iter()
+            .map(|f| f.json())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        clean_json_brackets(format!("{{\"fields\":[{}],\"type\":\"struct\"}}", fields))
+    }
+}
+
+/// A Field in a [StructType]
+#[derive(Clone, Debug)]
+pub struct StructField {
+    pub name: &'static str,
+    pub data_type: DataType,
+    pub nullable: bool,
+    pub metadata: Option<String>,
+}
+
+impl StructField {
+    pub fn new(
+        name: &'static str,
+        data_type: DataType,
+        nullable: Option<bool>,
+        metadata: Option<String>,
+    ) -> Self {
+        StructField {
+            name,
+            data_type,
+            nullable: nullable.unwrap_or(true),
+            metadata,
+        }
+    }
+
+    pub(crate) fn to_proto_type(&self) -> spark::data_type::StructField {
+        let data_type = self.data_type.clone().to_proto_type();
+
+        spark::data_type::StructField {
+            name: self.name.to_string(),
+            data_type: Some(data_type),
+            nullable: self.nullable,
+            metadata: self.metadata.clone(),
+        }
+    }
+}
+
+impl SparkDataType for StructField {
+    fn json(&self) -> String {
+        format!(
+            "{{\"name\":\"{}\",\"type\":\"{}\",\"nullable\":{},\"metadata\":{{}}}}",
+            self.name,
+            self.data_type.json(),
+            self.nullable
+        )
+    }
+}
+
+/// A set of DataTypes which represent Spark DataTypes.
+///
+/// These DataTypes variants are used to constructs a schema representation
+///
+/// # Example:
+///
+/// ```
+/// let schema = StructType::new(vec![
+///        StructField {
+///             name: "name",
+///             data_type: DataType::String,
+///             nullable: false,
+///             metadata: None,
+///         },
+///         StructField {
+///             name: "age",
+///             data_type: DataType::Short,
+///             nullable: true,
+///             metadata: None,
+///         },
+///     ]);
+/// ```
+#[derive(Clone, Debug)]
+pub enum DataType {
+    /// NullType
+    Null,
+    /// BinaryType
+    Binary,
+    /// BooleanType
+    Boolean,
+    /// ByteType
+    Byte,
+    /// ShortType
+    Short,
+    /// IntegerType
+    Integer,
+    /// LongType
+    Long,
+    /// FloatType
+    Float,
+    /// DoubleType
+    Double,
+    /// DecimalType with scale and precision
+    Decimal {
+        scale: Option<i32>,
+        precision: Option<i32>,
+    },
+    /// StringType
+    String,
+    /// CharType with length
+    Char(i32),
+    /// VarCharType with length
+    VarChar(i32),
+    /// DateType
+    Date,
+    /// TimestampType
+    Timestamp,
+    /// TimestampNtzType
+    TimestampNtz,
+    /// CalendarIntervalType
+    CalendarInterval,
+    /// YearMonthIntervalType
+    YearMonthInterval {
+        start_field: Option<i32>,
+        end_field: Option<i32>,
+    },
+    /// DayTimeInterval Type
+    DayTimeInterval {
+        start_field: Option<i32>,
+        end_field: Option<i32>,
+    },
+    /// ArrayType
+    Array {
+        element_type: Box<DataType>,
+        contains_null: bool,
+    },
+    /// MapType
+    Map {
+        key_type: Box<DataType>,
+        value_type: Box<DataType>,
+        value_contains_null: bool,
+    },
+    /// StructType
+    Struct(Box<StructType>),
+}
+
+impl DataType {
+    pub fn from_str_name(value: &str) -> DataType {
+        match value.to_lowercase().as_str() {
+            "bool" | "boolean" => DataType::Boolean,
+            "int" | "integer" => DataType::Integer,
+            "str" | "string" => DataType::String,
+            _ => unimplemented!("not implemented"),
+        }
+    }
+
+    pub fn to_proto_type(&self) -> spark::DataType {
+        let type_variation_reference = 0;
+
+        match self {
+            Self::Null => spark::DataType {
+                kind: Some(spark::data_type::Kind::Null(spark::data_type::Null {
+                    type_variation_reference,
+                })),
+            },
+            Self::Binary => spark::DataType {
+                kind: Some(spark::data_type::Kind::Binary(spark::data_type::Binary {
+                    type_variation_reference,
+                })),
+            },
+            Self::Boolean => spark::DataType {
+                kind: Some(spark::data_type::Kind::Boolean(spark::data_type::Boolean {
+                    type_variation_reference,
+                })),
+            },
+            Self::Byte => spark::DataType {
+                kind: Some(spark::data_type::Kind::Byte(spark::data_type::Byte {
+                    type_variation_reference,
+                })),
+            },
+            Self::Short => spark::DataType {
+                kind: Some(spark::data_type::Kind::Short(spark::data_type::Short {
+                    type_variation_reference,
+                })),
+            },
+            Self::Integer => spark::DataType {
+                kind: Some(spark::data_type::Kind::Integer(spark::data_type::Integer {
+                    type_variation_reference,
+                })),
+            },
+            Self::Long => spark::DataType {
+                kind: Some(spark::data_type::Kind::Long(spark::data_type::Long {
+                    type_variation_reference,
+                })),
+            },
+            Self::Float => spark::DataType {
+                kind: Some(spark::data_type::Kind::Float(spark::data_type::Float {
+                    type_variation_reference,
+                })),
+            },
+            Self::Double => spark::DataType {
+                kind: Some(spark::data_type::Kind::Double(spark::data_type::Double {
+                    type_variation_reference,
+                })),
+            },
+            Self::String => spark::DataType {
+                kind: Some(spark::data_type::Kind::String(spark::data_type::String {
+                    type_variation_reference,
+                })),
+            },
+            Self::Date => spark::DataType {
+                kind: Some(spark::data_type::Kind::Date(spark::data_type::Date {
+                    type_variation_reference,
+                })),
+            },
+            Self::Timestamp => spark::DataType {
+                kind: Some(spark::data_type::Kind::Timestamp(
+                    spark::data_type::Timestamp {
+                        type_variation_reference,
+                    },
+                )),
+            },
+            Self::TimestampNtz => spark::DataType {
+                kind: Some(spark::data_type::Kind::TimestampNtz(
+                    spark::data_type::TimestampNtz {
+                        type_variation_reference,
+                    },
+                )),
+            },
+            Self::CalendarInterval => spark::DataType {
+                kind: Some(spark::data_type::Kind::CalendarInterval(
+                    spark::data_type::CalendarInterval {
+                        type_variation_reference,
+                    },
+                )),
+            },
+            Self::Decimal { scale, precision } => spark::DataType {
+                kind: Some(spark::data_type::Kind::Decimal(spark::data_type::Decimal {
+                    scale: *scale,
+                    precision: *precision,
+                    type_variation_reference,
+                })),
+            },
+            Self::Char(length) => spark::DataType {
+                kind: Some(spark::data_type::Kind::Char(spark::data_type::Char {
+                    length: *length,
+                    type_variation_reference,
+                })),
+            },
+            Self::VarChar(length) => spark::DataType {
+                kind: Some(spark::data_type::Kind::Char(spark::data_type::Char {
+                    length: *length,
+                    type_variation_reference,
+                })),
+            },
+            Self::YearMonthInterval {
+                start_field,
+                end_field,
+            } => spark::DataType {
+                kind: Some(spark::data_type::Kind::YearMonthInterval(
+                    spark::data_type::YearMonthInterval {
+                        start_field: *start_field,
+                        end_field: *end_field,
+                        type_variation_reference,
+                    },
+                )),
+            },
+            Self::DayTimeInterval {
+                start_field,
+                end_field,
+            } => spark::DataType {
+                kind: Some(spark::data_type::Kind::DayTimeInterval(
+                    spark::data_type::DayTimeInterval {
+                        start_field: *start_field,
+                        end_field: *end_field,
+                        type_variation_reference,
+                    },
+                )),
+            },
+            Self::Array {
+                element_type,
+                contains_null,
+            } => spark::DataType {
+                kind: Some(spark::data_type::Kind::Array(Box::new(
+                    spark::data_type::Array {
+                        element_type: Some(Box::new(element_type.to_proto_type())),
+                        contains_null: *contains_null,
+                        type_variation_reference,
+                    },
+                ))),
+            },
+            Self::Map {
+                key_type,
+                value_type,
+                value_contains_null,
+            } => spark::DataType {
+                kind: Some(spark::data_type::Kind::Map(Box::new(
+                    spark::data_type::Map {
+                        key_type: Some(Box::new(key_type.to_proto_type())),
+                        value_type: Some(Box::new(value_type.to_proto_type())),
+                        value_contains_null: *value_contains_null,
+                        type_variation_reference,
+                    },
+                ))),
+            },
+
+            Self::Struct(val) => {
+                let fields = val
+                    .fields()
+                    .iter()
+                    .map(|f| f.clone().to_proto_type())
+                    .collect();
+
+                spark::DataType {
+                    kind: Some(spark::data_type::Kind::Struct(spark::data_type::Struct {
+                        fields,
+                        type_variation_reference,
+                    })),
+                }
+            }
+        }
+    }
+}
+
+impl SparkDataType for DataType {
+    fn json(&self) -> String {
+        match self {
+            Self::Null => String::from("void"),
+            Self::Binary => String::from("binary"),
+            Self::Boolean => String::from("boolean"),
+            Self::Byte => String::from("byte"),
+            Self::Short => String::from("short"),
+            Self::Integer => String::from("integer"),
+            Self::Long => String::from("long"),
+            Self::Float => String::from("float"),
+            Self::Double => String::from("double"),
+            Self::Decimal { scale, precision } => {
+                format!(
+                    "decimal({},{})",
+                    scale.unwrap_or(10),
+                    precision.unwrap_or(0)
+                )
+            }
+            Self::String => String::from("string"),
+            Self::Char(length) => format!("char({})", length),
+            Self::VarChar(length) => format!("varchar({})", length),
+            Self::Date => String::from("date"),
+
+            Self::Timestamp => String::from("timestamp"),
+            Self::TimestampNtz => String::from("timestamp_ntz"),
+            Self::CalendarInterval => String::from("interval"),
+            Self::YearMonthInterval {
+                start_field,
+                end_field,
+            } => {
+                let start = start_field.unwrap_or(0);
+                let end = end_field.unwrap_or(1);
+                match (start, end) {
+                    (0, 0) => String::from("interval year"),
+                    (0, 1) => String::from("interval month to year"),
+                    (1, 1) => String::from("interval month"),
+                    (1, 0) => String::from("interval year to month"),
+                    (_, _) => unimplemented!("Invalid YearMonthInterval"),
+                }
+            }
+            Self::DayTimeInterval {
+                start_field,
+                end_field,
+            } => {
+                let start = start_field.unwrap_or(0);
+                let end = end_field.unwrap_or(3);
+                match (start, end) {
+                    (0, 0) => String::from("interval day"),
+                    (0, 1) => String::from("interval day to hour"),
+                    (0, 2) => String::from("interval day to minute"),
+                    (0, 3) => String::from("interval day to second"),
+                    (1, 0) => String::from("interval hour to day"),
+                    (1, 1) => String::from("interval hour"),
+                    (1, 2) => String::from("interval hour to minute"),
+                    (1, 3) => String::from("interval hour to second"),
+                    (2, 0) => String::from("interval minute to day"),
+                    (2, 1) => String::from("interval minute to hour"),
+                    (2, 2) => String::from("interval minute"),
+                    (2, 3) => String::from("interval minute to second"),
+                    (3, 0) => String::from("interval second to day"),
+                    (3, 1) => String::from("interval second to hour"),
+                    (3, 2) => String::from("interval second to minute"),
+                    (3, 3) => String::from("interval second"),
+                    (_, _) => unimplemented!("Invalid DayTimeInterval"),
+                }
+            }
+            Self::Array {
+                element_type,
+                contains_null,
+            } => clean_json_brackets(format!(
+                "{{\"type\":\"array\",\"elementType\":{},\"containsNull\":{}}}",
+                element_type.json(),
+                contains_null
+            )),
+            Self::Map {
+                key_type,
+                value_type,
+                value_contains_null,
+            } => clean_json_brackets(format!(
+                "{{\"type\":\"map\",\"keyType\":{},\"valueType\":{},\"valueContainsNull\":{}}}",
+                key_type.json(),
+                value_type.json(),
+                value_contains_null
+            )),
+            Self::Struct(val) => val.json(),
+        }
+    }
+}
+
+impl From<DataType> for spark::DataType {
+    fn from(value: DataType) -> spark::DataType {
+        value.to_proto_type()
+    }
+}
+
+macro_rules! impl_to_proto_type {
     ($type:ty, $inner_type:ident) => {
-        impl ToDataType for $type {
-            fn to_proto_type(&self) -> spark::DataType {
+        impl From<$type> for spark::DataType {
+            fn from(_value: $type) -> spark::DataType {
                 spark::DataType {
                     kind: Some(spark::data_type::Kind::$inner_type(
                         spark::data_type::$inner_type {
@@ -22,18 +558,18 @@ macro_rules! impl_to_data_type {
     };
 }
 // Call the macro with the input pairs
-impl_to_data_type!(bool, Boolean);
-impl_to_data_type!(i16, Short);
-impl_to_data_type!(i32, Integer);
-impl_to_data_type!(i64, Long);
-impl_to_data_type!(isize, Long);
-impl_to_data_type!(f32, Float);
-impl_to_data_type!(f64, Double);
-impl_to_data_type!(&str, String);
-impl_to_data_type!(String, String);
+impl_to_proto_type!(bool, Boolean);
+impl_to_proto_type!(i16, Short);
+impl_to_proto_type!(i32, Integer);
+impl_to_proto_type!(i64, Long);
+impl_to_proto_type!(isize, Long);
+impl_to_proto_type!(f32, Float);
+impl_to_proto_type!(f64, Double);
+impl_to_proto_type!(&str, String);
+impl_to_proto_type!(String, String);
 
-impl ToDataType for &[u8] {
-    fn to_proto_type(&self) -> spark::DataType {
+impl From<&[u8]> for spark::DataType {
+    fn from(_value: &[u8]) -> spark::DataType {
         spark::DataType {
             kind: Some(spark::data_type::Kind::Binary(spark::data_type::Binary {
                 type_variation_reference: 0,
@@ -42,8 +578,8 @@ impl ToDataType for &[u8] {
     }
 }
 
-impl ToDataType for chrono::NaiveDate {
-    fn to_proto_type(&self) -> spark::DataType {
+impl From<chrono::NaiveDate> for spark::DataType {
+    fn from(_value: chrono::NaiveDate) -> spark::DataType {
         spark::DataType {
             kind: Some(spark::data_type::Kind::Date(spark::data_type::Date {
                 type_variation_reference: 0,
@@ -52,8 +588,8 @@ impl ToDataType for chrono::NaiveDate {
     }
 }
 
-impl<Tz: chrono::TimeZone> ToDataType for chrono::DateTime<Tz> {
-    fn to_proto_type(&self) -> spark::DataType {
+impl<Tz: chrono::TimeZone> From<chrono::DateTime<Tz>> for spark::DataType {
+    fn from(_value: chrono::DateTime<Tz>) -> spark::DataType {
         spark::DataType {
             kind: Some(spark::data_type::Kind::Timestamp(
                 spark::data_type::Timestamp {
@@ -64,8 +600,8 @@ impl<Tz: chrono::TimeZone> ToDataType for chrono::DateTime<Tz> {
     }
 }
 
-impl ToDataType for chrono::NaiveDateTime {
-    fn to_proto_type(&self) -> spark::DataType {
+impl From<chrono::NaiveDateTime> for spark::DataType {
+    fn from(_value: chrono::NaiveDateTime) -> spark::DataType {
         spark::DataType {
             kind: Some(spark::data_type::Kind::TimestampNtz(
                 spark::data_type::TimestampNtz {
@@ -73,5 +609,92 @@ impl ToDataType for chrono::NaiveDateTime {
                 },
             )),
         }
+    }
+}
+
+pub(crate) fn clean_json_brackets(json: String) -> String {
+    json.replace("\"{", "{").replace("}\"", "}")
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_schema() {
+        let complex_schema = DataType::Array {
+            element_type: Box::new(DataType::Struct(Box::new(StructType::new(vec![
+                StructField {
+                    name: "col5",
+                    data_type: DataType::String,
+                    nullable: true,
+                    metadata: None,
+                },
+                StructField {
+                    name: "col6",
+                    data_type: DataType::Char(200),
+                    nullable: true,
+                    metadata: None,
+                },
+            ])))),
+            contains_null: true,
+        };
+
+        let schema = StructType::new(vec![
+            StructField {
+                name: "col1",
+                data_type: DataType::Integer,
+                nullable: false,
+                metadata: None,
+            },
+            StructField {
+                name: "col2",
+                data_type: DataType::Short,
+                nullable: false,
+                metadata: None,
+            },
+            StructField {
+                name: "col3",
+                data_type: DataType::Array {
+                    element_type: Box::new(DataType::String),
+                    contains_null: true,
+                },
+                nullable: false,
+                metadata: None,
+            },
+            StructField {
+                name: "col4",
+                data_type: complex_schema,
+                nullable: true,
+                metadata: None,
+            },
+            StructField {
+                name: "col7",
+                data_type: DataType::Map {
+                    key_type: Box::new(DataType::String),
+                    value_type: Box::new(DataType::Long),
+                    value_contains_null: true,
+                },
+                nullable: true,
+                metadata: None,
+            },
+        ]);
+
+        let expected: String = "{\"fields\":[{\"name\":\"col1\",\"type\":\
+            \"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\
+            \"col2\",\"type\":\"short\",\"nullable\":false,\"metadata\":{}},{\
+            \"name\":\"col3\",\"type\":{\"type\":\"array\",\"elementType\
+            \":string,\"containsNull\":true},\"nullable\":false,\"metadata\
+            \":{}},{\"name\":\"col4\",\"type\":{\"type\":\"array\",\"elementType\
+            \":{\"fields\":[{\"name\":\"col5\",\"type\":\"string\",\"nullable\
+            \":true,\"metadata\":{}},{\"name\":\"col6\",\"type\":\"char(200)\",\
+            \"nullable\":true,\"metadata\":{}}],\"type\":\"struct\"},\"containsNull\
+            \":true},\"nullable\":true,\"metadata\":{}},{\"name\":\"col7\",\
+            \"type\":{\"type\":\"map\",\"keyType\":string,\"valueType\":long,\
+            \"valueContainsNull\":true},\"nullable\":true,\"metadata\":{}}],\"type\":\"struct\"}"
+            .into();
+
+        assert_eq!(expected, schema.json());
     }
 }

--- a/examples/src/reader.rs
+++ b/examples/src/reader.rs
@@ -5,6 +5,7 @@
 use spark_connect_rs::{SparkSession, SparkSessionBuilder};
 
 use spark_connect_rs::functions as F;
+use spark_connect_rs::types::DataType;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,8 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let df = df
         .select([
             F::col("name"),
-            F::col("age").cast("int").alias("age_int"),
-            (F::lit(3.0) + F::col("age").cast("int")).alias("addition"),
+            F::col("age").cast(DataType::Integer).alias("age_int"),
+            (F::lit(3.0) + F::col("age_int")).alias("addition"),
         ])
         .sort([F::col("name").desc()]);
 


### PR DESCRIPTION
# Description

Implement data types based on the Spark Data Types
  - Create additional trait for `CastToDataType` to allow for a user to leverage `DataType` or `&str` when using `col("name").cast(...)`
  - Added the `schema` method on the `DataFrameReader` to specify the read schema
  - Create additional trait for `ToSchema` to allow users to specific a read schema using a `StructType` schema or `&str` representing a DDL string.
  - Updated the `reader` example to show a type cast with a `DataType`
  - Removed `ToProtoType` and implemented `From<T> for spark::DataType` instead. It's more idiomatic
  - Misc: reorganized the code in the column module and changed up some variable names

### Not Implemented

- The `fromJson` method that `StructType` and `StructField` have on the current API. 
- The dataframe method for `schema()` still returns the types from the protobuf. Will implement this change later.

### Usage

**As a schema option**
```rust
let schema = StructType::new(vec![
    StructField {
        name: "name",
        data_type: DataType::String,
        nullable: false,
        metadata: None,
    },
    StructField {
        name: "age",
        data_type: DataType::Short,
        nullable: true,
        metadata: None,
    },
]);

let df = spark
    .clone()
    .read()
    .format("json")
    .schema(schema)
    .load(path)?;
```

**As a column cast**

```rust
let df = df
    .select([
        F::col("name").cast(DataType::String).alias("name_str"),
        F::col("age").cast(DataType::Integer).alias("age_int"),
    ]);
```