### PR TITLE
feat(session): add RunTimeConfig & Session tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,36 +85,36 @@ The following section outlines some of the larger functionality that are not yet
 |------------------|----------|---------------------------------------|
 |active            |![open]   |                                       |
 |addArtifact(s)    |![open]   |                                       |
-|addTag            |![open]   |                                       |
-|clearTags         |![open]   |                                       |
+|addTag            |![done]   |                                       |
+|clearTags         |![done]   |                                       |
 |copyFromLocalToFs |![open]   |                                       |
 |createDataFrame   |![partial]|Partial. Only works for `RecordBatch`  |
 |getActiveSessions |![open]   |                                       |
-|getTags           |![open]   |                                       |
-|interruptAll      |![open]   |                                       |
-|interruptOperation|![open]   |                                       |
-|interruptTag      |![open]   |                                       |
+|getTags           |![done]   |                                       |
+|interruptAll      |![done]   |                                       |
+|interruptOperation|![done]   |                                       |
+|interruptTag      |![done]   |                                       |
 |newSession        |![open]   |                                       |
 |range             |![done]   |                                       |
 |removeTag         |![done]   |                                       |
 |sql               |![done]   |                                       |
 |stop              |![open]   |                                       |
 |table             |![done]   |                                       |
-|catalog           |![done]   |[Catalog](#catalog)                  |
-|client            |X         |unstable developer api for testing only|
-|conf              |![open]   |[Conf](#runtimeconfig)                  |
-|read              |![done]   |[DataFrameReader](#dataframereader)                  |
-|readStream        |![done]   |[DataStreamReader](#datastreamreader)                  |
-|streams           |![open]   |[Streams](#streamingquerymanager)                  |
-|udf               |![open]   |[Udf](#udfregistration) - may not be possible                 |
-|udtf              |![open]   |[Udtf](#udtfregistration) - may not be possible                 |
-|version           |![open]   |                                       |
+|catalog           |![done]   |[Catalog](#catalog)                    |
+|client            |![done]   |unstable developer api for testing only |
+|conf              |![done]   |[Conf](#runtimeconfig)                 |
+|read              |![done]   |[DataFrameReader](#dataframereader)    |
+|readStream        |![done]   |[DataStreamReader](#datastreamreader)  |
+|streams           |![open]   |[Streams](#streamingquerymanager)      |
+|udf               |![open]   |[Udf](#udfregistration) - may not be possible   |
+|udtf              |![open]   |[Udtf](#udtfregistration) - may not be possible |
+|version           |![done]   |                                       |
 
 ### SparkSessionBuilder
 |SparkSessionBuilder|API       |Comment                                |
 |-------------------|----------|---------------------------------------|
-|appName            |![open]   |                                       |
-|config             |![open]   |                                       |
+|appName            |![done]   |                                       |
+|config             |![done]   |                                       |
 |master             |![open]   |                                       |
 |remote             |![partial]|Validate using [spark connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md)|
 

--- a/core/src/column.rs
+++ b/core/src/column.rs
@@ -41,7 +41,7 @@ pub struct Column {
     pub expression: spark::Expression,
 }
 
-/// Trait used to cast columns to specific [DataTypes]
+/// Trait used to cast columns to a specific [DataType]
 ///
 /// Either with a String or a [DataType]
 pub trait CastToDataType {

--- a/core/src/conf.rs
+++ b/core/src/conf.rs
@@ -1,0 +1,139 @@
+//! Configuration for a Spark application. Used to set various Spark parameters as key-value pairs.
+
+use std::collections::HashMap;
+
+use crate::spark;
+
+use crate::client::{MetadataInterceptor, SparkConnectClient};
+use crate::errors::SparkError;
+
+use tonic::service::interceptor::InterceptedService;
+
+#[cfg(not(feature = "wasm"))]
+use tonic::transport::Channel;
+
+#[cfg(feature = "wasm")]
+use tonic_web_wasm_client::Client;
+
+pub struct RunTimeConfig {
+    #[cfg(not(feature = "wasm"))]
+    pub(crate) client: SparkConnectClient<InterceptedService<Channel, MetadataInterceptor>>,
+
+    #[cfg(feature = "wasm")]
+    pub(crate) client: SparkConnectClient<InterceptedService<Client, MetadataInterceptor>>,
+}
+
+/// User-facing configuration API, accessible through SparkSession.conf.
+///
+/// Options set here are automatically propagated to the Hadoop configuration during I/O.
+///
+/// # Example
+/// ```rust
+/// spark
+///    .conf()
+///    .set("spark.sql.shuffle.partitions", "42")
+///    .await?;
+/// ```
+impl RunTimeConfig {
+    #[allow(dead_code)]
+    pub(crate) async fn set_configs(
+        &mut self,
+        map: &HashMap<String, String>,
+    ) -> Result<(), SparkError> {
+        for (key, value) in map {
+            self.set(key.as_str(), value.as_str()).await?
+        }
+        Ok(())
+    }
+
+    /// Sets the given Spark runtime configuration property.
+    pub async fn set(&mut self, key: &str, value: &str) -> Result<(), SparkError> {
+        let op_type = spark::config_request::operation::OpType::Set(spark::config_request::Set {
+            pairs: vec![spark::KeyValue {
+                key: key.into(),
+                value: Some(value.into()),
+            }],
+        });
+        let operation = spark::config_request::Operation {
+            op_type: Some(op_type),
+        };
+
+        let _ = self.client.config_request(operation).await?;
+
+        Ok(())
+    }
+
+    /// Resets the configuration property for the given key.
+    pub async fn unset(&mut self, key: &str) -> Result<(), SparkError> {
+        let op_type =
+            spark::config_request::operation::OpType::Unset(spark::config_request::Unset {
+                keys: vec![key.to_string()],
+            });
+        let operation = spark::config_request::Operation {
+            op_type: Some(op_type),
+        };
+
+        let _ = self.client.config_request(operation).await?;
+
+        Ok(())
+    }
+
+    /// Indicates whether the configuration property with the given key is modifiable in the current session.
+    pub async fn get(&mut self, key: &str, default: Option<&str>) -> Result<String, SparkError> {
+        let operation = match default {
+            Some(default) => {
+                let op_type = spark::config_request::operation::OpType::GetWithDefault(
+                    spark::config_request::GetWithDefault {
+                        pairs: vec![spark::KeyValue {
+                            key: key.into(),
+                            value: Some(default.into()),
+                        }],
+                    },
+                );
+                spark::config_request::Operation {
+                    op_type: Some(op_type),
+                }
+            }
+            None => {
+                let op_type =
+                    spark::config_request::operation::OpType::Get(spark::config_request::Get {
+                        keys: vec![key.to_string()],
+                    });
+                spark::config_request::Operation {
+                    op_type: Some(op_type),
+                }
+            }
+        };
+
+        let resp = self.client.config_request(operation).await?;
+
+        let val = resp.pairs.first().unwrap().value().to_string();
+
+        Ok(val)
+    }
+
+    /// Indicates whether the configuration property with the given key is modifiable in the current session.
+    #[allow(non_snake_case)]
+    pub async fn isModifable(&mut self, key: &str) -> Result<bool, SparkError> {
+        let op_type = spark::config_request::operation::OpType::IsModifiable(
+            spark::config_request::IsModifiable {
+                keys: vec![key.to_string()],
+            },
+        );
+        let operation = spark::config_request::Operation {
+            op_type: Some(op_type),
+        };
+
+        let resp = self.client.config_request(operation).await?;
+
+        let val = resp.pairs.first().unwrap().value();
+
+        match val {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(SparkError::AnalysisException(
+                "Unexpected response value for boolean".to_string(),
+            )),
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,6 +118,7 @@ pub mod spark {
 pub mod catalog;
 pub mod client;
 pub mod column;
+pub mod conf;
 pub mod dataframe;
 pub mod errors;
 pub mod expressions;

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::catalog::Catalog;
+use crate::conf::RunTimeConfig;
 use crate::dataframe::{DataFrame, DataFrameReader};
 use crate::plan::LogicalPlanBuilder;
 use crate::spark;
@@ -31,6 +32,7 @@ use tonic::service::interceptor::InterceptedService;
 #[derive(Clone, Debug)]
 pub struct SparkSessionBuilder {
     pub channel_builder: ChannelBuilder,
+    configs: HashMap<String, String>,
 }
 
 /// Default connects a Spark cluster running at `sc://127.0.0.1:15002/`
@@ -38,7 +40,10 @@ impl Default for SparkSessionBuilder {
     fn default() -> Self {
         let channel_builder = ChannelBuilder::default();
 
-        Self { channel_builder }
+        Self {
+            channel_builder,
+            configs: HashMap::new(),
+        }
     }
 }
 
@@ -46,7 +51,10 @@ impl SparkSessionBuilder {
     fn new(connection: &str) -> Self {
         let channel_builder = ChannelBuilder::create(connection).unwrap();
 
-        Self { channel_builder }
+        Self {
+            channel_builder,
+            configs: HashMap::new(),
+        }
     }
 
     /// Validate a connect string for a remote Spark Session
@@ -54,6 +62,20 @@ impl SparkSessionBuilder {
     /// String must conform to the [Spark Documentation](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md)
     pub fn remote(connection: &str) -> Self {
         Self::new(connection)
+    }
+
+    /// Sets a config option.
+    pub fn config(mut self, key: &str, value: &str) -> Self {
+        self.configs.insert(key.into(), value.into());
+        self
+    }
+
+    /// Sets a name for the application, which will be shown in the Spark web UI.
+    #[allow(non_snake_case)]
+    pub fn appName(mut self, name: &str) -> Self {
+        self.configs
+            .insert("spark.app.name".to_string(), name.into());
+        self
     }
 
     #[cfg(not(feature = "wasm"))]
@@ -76,6 +98,12 @@ impl SparkSessionBuilder {
 
         let spark_connnect_client =
             SparkConnectClient::new(client.clone(), self.channel_builder.clone());
+
+        let mut rt_config = RunTimeConfig {
+            client: spark_connnect_client.clone(),
+        };
+
+        rt_config.set_configs(&self.configs).await?;
 
         Ok(SparkSession::new(spark_connnect_client))
     }
@@ -228,6 +256,87 @@ impl SparkSession {
     pub fn client(self) -> SparkConnectClient<InterceptedService<Client, MetadataInterceptor>> {
         self.client
     }
+
+    /// Interrupt all operations of this session currently running on the connected server.
+    #[allow(non_snake_case)]
+    pub async fn interruptAll(self) -> Result<Vec<String>, SparkError> {
+        let resp = self
+            .client()
+            .interrupt_request(spark::interrupt_request::InterruptType::All, None)
+            .await?;
+
+        Ok(resp.interrupted_ids)
+    }
+
+    /// Interrupt all operations of this session with the given operation tag.
+    #[allow(non_snake_case)]
+    pub async fn interruptTag(self, tag: &str) -> Result<Vec<String>, SparkError> {
+        let resp = self
+            .client()
+            .interrupt_request(
+                spark::interrupt_request::InterruptType::Tag,
+                Some(tag.to_string()),
+            )
+            .await?;
+
+        Ok(resp.interrupted_ids)
+    }
+
+    /// Interrupt an operation of this session with the given operationId.
+    #[allow(non_snake_case)]
+    pub async fn interruptOperation(self, op_id: &str) -> Result<Vec<String>, SparkError> {
+        let resp = self
+            .client()
+            .interrupt_request(
+                spark::interrupt_request::InterruptType::OperationId,
+                Some(op_id.to_string()),
+            )
+            .await?;
+
+        Ok(resp.interrupted_ids)
+    }
+
+    /// Add a tag to be assigned to all the operations started by this thread in this session.
+    #[allow(non_snake_case)]
+    pub fn addTag(&mut self, tag: &str) -> Result<(), SparkError> {
+        self.client.add_tag(tag)
+    }
+
+    /// Remove a tag previously added to be assigned to all the operations started by this thread in this session.
+    #[allow(non_snake_case)]
+    pub fn removeTag(&mut self, tag: &str) -> Result<(), SparkError> {
+        self.client.remove_tag(tag)
+    }
+
+    /// Get the tags that are currently set to be assigned to all the operations started by this thread.
+    #[allow(non_snake_case)]
+    pub fn getTags(&mut self) -> &Vec<String> {
+        self.client.get_tags()
+    }
+
+    /// Clear the current thread’s operation tags.
+    #[allow(non_snake_case)]
+    pub fn clearTags(&mut self) {
+        self.client.clear_tags()
+    }
+
+    /// The version of Spark on which this application is running.
+    pub async fn version(self) -> Result<String, SparkError> {
+        let version = spark::analyze_plan_request::Analyze::SparkVersion(
+            spark::analyze_plan_request::SparkVersion {},
+        );
+
+        let mut client = self.client;
+
+        client.analyze(version).await?.spark_version()
+    }
+
+    /// [RunTimeConfig] configuration interface for Spark.
+    pub fn conf(&self) -> RunTimeConfig {
+        RunTimeConfig {
+            client: self.client.clone(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -235,7 +344,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_spark_session_builder() {
+    fn test_session_builder() {
         let connection = "sc://myhost.com:443/;token=ABCDEFG;user_agent=some_agent;user_id=user123";
 
         let ssbuilder = SparkSessionBuilder::remote(connection);
@@ -258,5 +367,103 @@ mod tests {
         let spark = SparkSessionBuilder::remote(connection).build().await;
 
         assert!(spark.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_session_tags() -> Result<(), SparkError> {
+        let mut spark = SparkSessionBuilder::default().build().await?;
+
+        spark.addTag("hello-tag")?;
+
+        spark.addTag("hello-tag-2")?;
+
+        let expected = vec!["hello-tag".to_string(), "hello-tag-2".to_string()];
+
+        let res = spark.getTags();
+
+        assert_eq!(&expected, res);
+
+        spark.clearTags();
+        let res = spark.getTags();
+
+        let expected: Vec<String> = vec![];
+
+        assert_eq!(&expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_session_tags_panic() -> Result<(), SparkError> {
+        let mut spark = SparkSessionBuilder::default().build().await?;
+
+        assert!(spark.addTag("bad,tag").is_err());
+        assert!(spark.addTag("").is_err());
+
+        assert!(spark.removeTag("bad,tag").is_err());
+        assert!(spark.removeTag("").is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_session_version() -> Result<(), SparkError> {
+        let spark = SparkSessionBuilder::default().build().await?;
+
+        let version = spark.version().await?;
+
+        assert_eq!("3.5.1".to_string(), version);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_session_config() -> Result<(), SparkError> {
+        let value = "rust-test-app";
+
+        let spark = SparkSessionBuilder::default()
+            .appName("rust-test-app")
+            .build()
+            .await?;
+
+        let name = spark.conf().get("spark.app.name", None).await?;
+
+        assert_eq!(value, &name);
+
+        // validate set
+        spark
+            .conf()
+            .set("spark.sql.shuffle.partitions", "42")
+            .await?;
+
+        // validate get
+        let val = spark
+            .conf()
+            .get("spark.sql.shuffle.partitions", None)
+            .await?;
+
+        assert_eq!("42", &val);
+
+        // validate unset
+        spark.conf().unset("spark.sql.shuffle.partitions").await?;
+
+        let val = spark
+            .conf()
+            .get("spark.sql.shuffle.partitions", None)
+            .await?;
+
+        assert_eq!("200", &val);
+
+        // not a modifable setting
+        let val = spark.conf().isModifable("spark.executor.instances").await?;
+        assert!(!val);
+
+        // a modifable setting
+        let val = spark
+            .conf()
+            .isModifable("spark.sql.shuffle.partitions")
+            .await?;
+        assert!(val);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
# Description

feat(session): add RunTimeConfig & Session tags
- add the ability to get/set spark configs via `conf` and `appName`
- add the ability to get/set spark session tags
- fix issue with rust docs on the column 

