### PR TITLE
test(core): add a concurrent spark session test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [main, "v*"]
+    branches: [main, "v*", "dev"]
   pull_request:
-    branches: [main, "v*"]
+    branches: [main, "v*", "dev"]
 
 jobs:
   format:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ dependencies = [
  "arrow-ipc",
  "chrono",
  "datafusion",
+ "futures",
  "getrandom",
  "parking_lot",
  "polars",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,9 @@ polars-arrow = { workspace = true, optional = true }
 [build-dependencies]
 tonic-build = "0.11.0"
 
+[dev-dependencies]
+futures = "0.3"
+
 [lib]
 doctest = false
 

--- a/core/src/dataframe.rs
+++ b/core/src/dataframe.rs
@@ -1609,6 +1609,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_df_explain_concurrent() -> Result<(), SparkError> {
+        let spark = setup().await;
+        let spark_clone = spark.clone();
+
+        let data = mock_data();
+
+        let df = spark.createDataFrame(&data)?;
+        let df_clone = spark_clone.createDataFrame(&data)?;
+
+        let (res, res_clone) = futures::join!(df.explain(None), df_clone.explain(None));
+        let (val, val_clone) = (res?, res_clone?);
+
+        assert!(val.contains("== Physical Plan =="));
+        assert!(val_clone.contains("== Physical Plan =="));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_df_filter() -> Result<(), SparkError> {
         let spark = setup().await;
 


### PR DESCRIPTION
# Description

This PR demonstrates that a simple concurrent spark sessions may lead to a deadlock because of the use of synchronous locks across awaits.

# Related Issue(s)

https://github.com/sjrusso8/spark-connect-rs/issues/47

# Documentation