### PR TITLE
refactor(session): use ref for session methods & error messages

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -453,7 +453,7 @@ where
     }
 
     pub async fn interrupt_request(
-        &mut self,
+        &self,
         interrupt_type: spark::interrupt_request::InterruptType,
         id_or_tag: Option<String>,
     ) -> Result<spark::InterruptResponse, SparkError> {
@@ -532,7 +532,7 @@ where
     }
 
     pub async fn config_request(
-        &mut self,
+        &self,
         operation: spark::config_request::Operation,
     ) -> Result<spark::ConfigResponse, SparkError> {
         let operation = spark::ConfigRequest {
@@ -713,48 +713,74 @@ where
         Ok(data.value(0).to_string())
     }
 
-    pub fn schema(&mut self) -> Result<spark::DataType, SparkError> {
-        Ok(self.analyzer.schema.to_owned().unwrap())
+    pub fn schema(&self) -> Result<spark::DataType, SparkError> {
+        self.analyzer
+            .schema
+            .to_owned()
+            .ok_or_else(|| SparkError::AnalysisException("Schema response is empty".to_string()))
     }
 
-    pub fn explain(&mut self) -> Result<String, SparkError> {
-        Ok(self.analyzer.explain.to_owned().unwrap())
+    pub fn explain(&self) -> Result<String, SparkError> {
+        self.analyzer
+            .explain
+            .to_owned()
+            .ok_or_else(|| SparkError::AnalysisException("Explain response is empty".to_string()))
     }
 
-    pub fn tree_string(&mut self) -> Result<String, SparkError> {
-        Ok(self.analyzer.tree_string.to_owned().unwrap())
+    pub fn tree_string(&self) -> Result<String, SparkError> {
+        self.analyzer.tree_string.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Tree String response is empty".to_string())
+        })
     }
 
-    pub fn is_local(&mut self) -> Result<bool, SparkError> {
-        Ok(self.analyzer.is_local.to_owned().unwrap())
+    pub fn is_local(&self) -> Result<bool, SparkError> {
+        self.analyzer
+            .is_local
+            .to_owned()
+            .ok_or_else(|| SparkError::AnalysisException("Is Local response is empty".to_string()))
     }
 
-    pub fn is_streaming(&mut self) -> Result<bool, SparkError> {
-        Ok(self.analyzer.is_streaming.to_owned().unwrap())
+    pub fn is_streaming(&self) -> Result<bool, SparkError> {
+        self.analyzer.is_streaming.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Is Streaming response is empty".to_string())
+        })
     }
 
-    pub fn input_files(&mut self) -> Result<Vec<String>, SparkError> {
-        Ok(self.analyzer.input_files.to_owned().unwrap())
+    pub fn input_files(&self) -> Result<Vec<String>, SparkError> {
+        self.analyzer.input_files.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Input Files response is empty".to_string())
+        })
     }
 
     pub fn spark_version(&mut self) -> Result<String, SparkError> {
-        Ok(self.analyzer.spark_version.to_owned().unwrap())
+        self.analyzer.spark_version.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Spark Version resonse is empty".to_string())
+        })
     }
 
-    pub fn ddl_parse(&mut self) -> Result<spark::DataType, SparkError> {
-        Ok(self.analyzer.ddl_parse.to_owned().unwrap())
+    pub fn ddl_parse(&self) -> Result<spark::DataType, SparkError> {
+        self.analyzer
+            .ddl_parse
+            .to_owned()
+            .ok_or_else(|| SparkError::AnalysisException("DDL parse response is empty".to_string()))
     }
 
-    pub fn same_semantics(&mut self) -> Result<bool, SparkError> {
-        Ok(self.analyzer.same_semantics.to_owned().unwrap())
+    pub fn same_semantics(&self) -> Result<bool, SparkError> {
+        self.analyzer.same_semantics.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Same Semantics response is empty".to_string())
+        })
     }
 
-    pub fn semantic_hash(&mut self) -> Result<i32, SparkError> {
-        Ok(self.analyzer.semantic_hash.to_owned().unwrap())
+    pub fn semantic_hash(&self) -> Result<i32, SparkError> {
+        self.analyzer.semantic_hash.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Semantic Hash response is empty".to_string())
+        })
     }
 
-    pub fn get_storage_level(&mut self) -> Result<spark::StorageLevel, SparkError> {
-        Ok(self.analyzer.get_storage_level.to_owned().unwrap())
+    pub fn get_storage_level(&self) -> Result<spark::StorageLevel, SparkError> {
+        self.analyzer.get_storage_level.to_owned().ok_or_else(|| {
+            SparkError::AnalysisException("Storage Level response is empty".to_string())
+        })
     }
 }
 

--- a/core/src/dataframe.rs
+++ b/core/src/dataframe.rs
@@ -1323,11 +1323,7 @@ mod tests {
 
         let data = RecordBatch::try_from_iter(vec![("c1", c1), ("c2", c2)])?;
 
-        let val = spark
-            .clone()
-            .createDataFrame(&data)?
-            .cov("c1", "c2")
-            .await?;
+        let val = spark.createDataFrame(&data)?.cov("c1", "c2").await?;
 
         assert_eq!(-18.0_f64, val);
 
@@ -1350,7 +1346,6 @@ mod tests {
         let data = mock_data();
 
         spark
-            .clone()
             .createDataFrame(&data)?
             .createOrReplaceGlobalTempView("people")
             .await?;
@@ -1392,7 +1387,7 @@ mod tests {
         let data = RecordBatch::try_from_iter(vec![("name", name.clone()), ("age", age)])?;
         let data2 = RecordBatch::try_from_iter(vec![("name", name), ("height", height)])?;
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
         let df2 = spark.createDataFrame(&data2)?;
 
         let rows = df
@@ -1578,7 +1573,7 @@ mod tests {
 
         let data2 = RecordBatch::try_from_iter(vec![("c1", c1), ("c2", c2)])?;
 
-        let df1 = spark.clone().createDataFrame(&data)?;
+        let df1 = spark.createDataFrame(&data)?;
 
         let df2 = spark.createDataFrame(&data2)?;
 
@@ -1726,7 +1721,7 @@ mod tests {
 
         let data = mock_data();
 
-        let df = spark.clone().createDataFrame(&data)?.alias("df1");
+        let df = spark.createDataFrame(&data)?.alias("df1");
         let df2 = spark.createDataFrame(&data)?.alias("df2");
 
         let df = df.join(
@@ -1775,7 +1770,7 @@ mod tests {
 
         let data2 = RecordBatch::try_from_iter(vec![("c1", c1), ("c2", c2)])?;
 
-        let df1 = spark.clone().createDataFrame(&data)?;
+        let df1 = spark.createDataFrame(&data)?;
 
         let df2 = spark.createDataFrame(&data2)?;
 
@@ -1800,7 +1795,7 @@ mod tests {
         let schema = Schema::new(vec![Field::new("record", DataType::Int64, true)]);
         let data = RecordBatch::try_new(Arc::new(schema), vec![records])?;
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
 
         assert!(df.isEmpty().await?);
 
@@ -1809,7 +1804,7 @@ mod tests {
         let schema = Schema::new(vec![Field::new("record", DataType::Int64, true)]);
         let data = RecordBatch::try_new(Arc::new(schema), vec![records])?;
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
 
         assert!(!df.isEmpty().await?);
 
@@ -1858,9 +1853,9 @@ mod tests {
 
         let data4 = RecordBatch::try_new(Arc::new(schema), vec![name, age, height])?;
 
-        let df1 = spark.clone().createDataFrame(&data1)?.alias("df1");
-        let df2 = spark.clone().createDataFrame(&data2)?.alias("df2");
-        let df3 = spark.clone().createDataFrame(&data3)?.alias("df3");
+        let df1 = spark.createDataFrame(&data1)?.alias("df1");
+        let df2 = spark.createDataFrame(&data2)?.alias("df2");
+        let df3 = spark.createDataFrame(&data3)?.alias("df3");
         let df4 = spark.createDataFrame(&data4)?.alias("df4");
 
         // inner join
@@ -2127,7 +2122,7 @@ mod tests {
 
         let data = mock_data();
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
 
         let val = df.toJSON().await?;
 
@@ -2155,7 +2150,7 @@ mod tests {
 
         let data = mock_data();
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
 
         let df_output = df.toDataFusion(&ctx).await?.collect().await?;
         let df_expected = ctx.read_batch(data)?.collect().await?;
@@ -2163,7 +2158,7 @@ mod tests {
         assert_eq!(df_expected, df_output);
 
         // empty dataframe
-        let df = spark.clone().range(Some(0), 0, 1, None);
+        let df = spark.range(Some(0), 0, 1, None);
 
         let val = df.toDataFusion(&ctx).await?.collect().await?;
 
@@ -2194,7 +2189,7 @@ mod tests {
 
         let df_expected = polars::frame::DataFrame::from_iter(columns);
 
-        let df = spark.clone().createDataFrame(&data)?;
+        let df = spark.createDataFrame(&data)?;
 
         let df_output = df.toPolars().await?;
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -331,7 +331,7 @@ impl SparkSession {
             spark::analyze_plan_request::SparkVersion {},
         );
 
-        let mut client = self.client.to_owned();
+        let mut client = self.client.clone();
 
         client.analyze(version).await?.spark_version()
     }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -170,12 +170,16 @@ impl SparkSession {
         }
     }
 
+    pub fn session(&self) -> SparkSession {
+        self.clone()
+    }
+
     /// Create a [DataFrame] with a spingle column named `id`,
     /// containing elements in a range from `start` (default 0) to
     /// `end` (exclusive) with a step value `step`, and control the number
     /// of partitions with `num_partitions`
     pub fn range(
-        self,
+        &self,
         start: Option<i64>,
         end: i64,
         step: i64,
@@ -188,32 +192,32 @@ impl SparkSession {
             num_partitions,
         });
 
-        DataFrame::new(self, LogicalPlanBuilder::from(range_relation))
+        DataFrame::new(self.session(), LogicalPlanBuilder::from(range_relation))
     }
 
     /// Returns a [DataFrameReader] that can be used to read datra in as a [DataFrame]
-    pub fn read(self) -> DataFrameReader {
-        DataFrameReader::new(self)
+    pub fn read(&self) -> DataFrameReader {
+        DataFrameReader::new(self.session())
     }
 
     /// Returns a [DataFrameReader] that can be used to read datra in as a [DataFrame]
     #[allow(non_snake_case)]
-    pub fn readStream(self) -> DataStreamReader {
-        DataStreamReader::new(self)
+    pub fn readStream(&self) -> DataStreamReader {
+        DataStreamReader::new(self.session())
     }
 
-    pub fn table(self, name: &str) -> Result<DataFrame, SparkError> {
-        DataFrameReader::new(self).table(name, None)
+    pub fn table(&self, name: &str) -> Result<DataFrame, SparkError> {
+        DataFrameReader::new(self.session()).table(name, None)
     }
 
     /// Interface through which the user may create, drop, alter or query underlying databases,
     /// tables, functions, etc.
-    pub fn catalog(self) -> Catalog {
-        Catalog::new(self)
+    pub fn catalog(&self) -> Catalog {
+        Catalog::new(self.session())
     }
 
     /// Returns a [DataFrame] representing the result of the given query
-    pub async fn sql(self, sql_query: &str) -> Result<DataFrame, SparkError> {
+    pub async fn sql(&self, sql_query: &str) -> Result<DataFrame, SparkError> {
         let sql_cmd = spark::command::CommandType::SqlCommand(spark::SqlCommand {
             sql: sql_query.to_string(),
             args: HashMap::default(),
@@ -232,14 +236,14 @@ impl SparkSession {
 
         let logical_plan = LogicalPlanBuilder::new(relation.unwrap());
 
-        Ok(DataFrame::new(self, logical_plan))
+        Ok(DataFrame::new(self.session(), logical_plan))
     }
 
     #[allow(non_snake_case)]
-    pub fn createDataFrame(self, data: &RecordBatch) -> Result<DataFrame, SparkError> {
+    pub fn createDataFrame(&self, data: &RecordBatch) -> Result<DataFrame, SparkError> {
         let logical_plan = LogicalPlanBuilder::local_relation(data)?;
 
-        Ok(DataFrame::new(self, logical_plan))
+        Ok(DataFrame::new(self.session(), logical_plan))
     }
 
     /// Return the session ID
@@ -260,9 +264,9 @@ impl SparkSession {
 
     /// Interrupt all operations of this session currently running on the connected server.
     #[allow(non_snake_case)]
-    pub async fn interruptAll(self) -> Result<Vec<String>, SparkError> {
+    pub async fn interruptAll(&self) -> Result<Vec<String>, SparkError> {
         let resp = self
-            .client()
+            .client
             .interrupt_request(spark::interrupt_request::InterruptType::All, None)
             .await?;
 
@@ -271,9 +275,9 @@ impl SparkSession {
 
     /// Interrupt all operations of this session with the given operation tag.
     #[allow(non_snake_case)]
-    pub async fn interruptTag(self, tag: &str) -> Result<Vec<String>, SparkError> {
+    pub async fn interruptTag(&self, tag: &str) -> Result<Vec<String>, SparkError> {
         let resp = self
-            .client()
+            .client
             .interrupt_request(
                 spark::interrupt_request::InterruptType::Tag,
                 Some(tag.to_string()),
@@ -285,9 +289,9 @@ impl SparkSession {
 
     /// Interrupt an operation of this session with the given operationId.
     #[allow(non_snake_case)]
-    pub async fn interruptOperation(self, op_id: &str) -> Result<Vec<String>, SparkError> {
+    pub async fn interruptOperation(&self, op_id: &str) -> Result<Vec<String>, SparkError> {
         let resp = self
-            .client()
+            .client
             .interrupt_request(
                 spark::interrupt_request::InterruptType::OperationId,
                 Some(op_id.to_string()),
@@ -322,12 +326,12 @@ impl SparkSession {
     }
 
     /// The version of Spark on which this application is running.
-    pub async fn version(self) -> Result<String, SparkError> {
+    pub async fn version(&self) -> Result<String, SparkError> {
         let version = spark::analyze_plan_request::Analyze::SparkVersion(
             spark::analyze_plan_request::SparkVersion {},
         );
 
-        let mut client = self.client;
+        let mut client = self.client.to_owned();
 
         client.analyze(version).await?.spark_version()
     }

--- a/examples/src/deltalake.rs
+++ b/examples/src/deltalake.rs
@@ -22,7 +22,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load a CSV file from the spark server
     let df = spark
-        .clone()
         .read()
         .format("csv")
         .option("header", "True")
@@ -39,7 +38,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // view the history of the table
     spark
-        .clone()
         .sql("DESCRIBE HISTORY default.people_delta")
         .await?
         .show(Some(1), None, Some(true))
@@ -47,7 +45,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create another dataframe
     let df = spark
-        .clone()
         .sql("SELECT 'john' as name, 40 as age, 'engineer' as job")
         .await?;
 
@@ -60,7 +57,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // view history
     spark
-        .clone()
         .sql("DESCRIBE HISTORY default.people_delta")
         .await?
         .show(Some(2), None, Some(true))

--- a/examples/src/sql.rs
+++ b/examples/src/sql.rs
@@ -10,10 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .await?;
 
-    let df = spark
-        .clone()
-        .sql("select 'apple' as word, 123 as count")
-        .await?;
+    let df = spark.sql("select 'apple' as word, 123 as count").await?;
 
     df.write()
         .mode(SaveMode::Overwrite)

--- a/examples/src/writer.rs
+++ b/examples/src/writer.rs
@@ -14,7 +14,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let df = spark
-        .clone()
         .range(None, 1000, 1, Some(16))
         .select(col("id").alias("range_id"));
 
@@ -28,7 +27,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let df = spark
-        .clone()
         .read()
         .format("csv")
         .option("header", "true")


### PR DESCRIPTION
# Description

refactor(session): use ref for session methods & error messages
  - change session methods to use `&self` where possible
  - update `client` to remove `.unwrap()` and use `ok_or_else` instead