### PR TITLE
Resolve issue with broken CI/CD Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             exit 1
           fi
         working-directory: ./core
-  # To do
+  # To do 
   # release-crate:
   #   needs: validate-release-tag
   #   name: Release crate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             echo "Cargo metadata has version set to ${CURR_VER}, but got pushed tag ${PUSHED_TAG}."
             exit 1
           fi
-        working-directory: ./core
+        # working-directory: ./core
   # To do 
   # release-crate:
   #   needs: validate-release-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
             echo "Cargo metadata has version set to ${CURR_VER}, but got pushed tag ${PUSHED_TAG}."
             exit 1
           fi
+        working-directory: ./core
   # To do
   # release-crate:
   #   needs: validate-release-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,36 +19,36 @@ jobs:
             exit 1
           fi
 
-  release-crate:
-    needs: validate-release-tag
-    name: Release crate
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
+  # release-crate:
+  #   needs: validate-release-tag
+  #   name: Release crate
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: stable
+  #         override: true
 
-      - name: install protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          version: 23.x
+  #     - name: install protoc
+  #       uses: arduino/setup-protoc@v2
+  #       with:
+  #         version: 23.x
 
-      - name: cargo publish core
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish
-          args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-core --manifest-path ./Cargo.toml
+  #     - name: cargo publish core
+  #       uses: actions-rs/cargo@v1
+  #       env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  #       with:
+  #         command: publish
+  #         args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-core --manifest-path ./Cargo.toml
 
-      - name: cargo publish rust
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish
-          args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-rs --manifest-path ./Cargo.toml
+  #     - name: cargo publish rust
+  #       uses: actions-rs/cargo@v1
+  #       env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  #       with:
+  #         command: publish
+  #         args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-rs --manifest-path ./Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,37 +19,37 @@ jobs:
             exit 1
           fi
         working-directory: ./core
-  # To do 
-  # release-crate:
-  #   needs: validate-release-tag
-  #   name: Release crate
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v4
 
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
+  release-crate:
+    needs: validate-release-tag
+    name: Release crate
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: install protoc
-  #       uses: arduino/setup-protoc@v2
-  #       with:
-  #         version: 23.x
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-  #     - name: cargo publish core
-  #       uses: actions-rs/cargo@v1
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #       with:
-  #         command: publish
-  #         args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-core --manifest-path ./Cargo.toml
+      - name: install protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: 23.x
 
-  #     - name: cargo publish rust
-  #       uses: actions-rs/cargo@v1
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #       with:
-  #         command: publish
-  #         args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-rs --manifest-path ./Cargo.toml
+      - name: cargo publish core
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: publish
+          args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-core --manifest-path ./Cargo.toml
+
+      - name: cargo publish rust
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: publish
+          args: --token "${CARGO_REGISTRY_TOKEN}" --package spark-connect-rs --manifest-path ./Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             echo "Cargo metadata has version set to ${CURR_VER}, but got pushed tag ${PUSHED_TAG}."
             exit 1
           fi
-        # working-directory: ./core
+        working-directory: ./core
   # To do 
   # release-crate:
   #   needs: validate-release-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             echo "Cargo metadata has version set to ${CURR_VER}, but got pushed tag ${PUSHED_TAG}."
             exit 1
           fi
-
+  # To do
   # release-crate:
   #   needs: validate-release-tag
   #   name: Release crate

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -968,6 +968,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_func_startswith() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("name").startswith("A"))
+            .select("name")
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_endswith() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("name").endswith("e"))
+            .select("name")
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_like() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("name").like("Alice"))
+            .select("name")
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_func_col_isin() -> Result<(), SparkError> {
         let spark = setup().await;
 
@@ -1138,10 +1210,5 @@ mod tests {
 
         assert_eq!(expected, res);
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_func_startswith() -> Result<(), SparkError> {
-        todo!()
     }
 }

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1064,6 +1064,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_func_rlike() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("name").rlike("ice$"))
+            .select("name")
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_eq() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        todo!();
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_func_col_isin() -> Result<(), SparkError> {
         let spark = setup().await;
 
@@ -1099,7 +1131,6 @@ mod tests {
         let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
 
         assert_eq!(expected, res);
-
         Ok(())
     }
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -978,7 +978,7 @@ mod tests {
         let df = spark.create_dataframe(&data)?;
 
         let res = df
-            .filter(col("name").startswith("A"))
+            .filter(col("name").startswith("Al"))
             .select("name")
             .collect()
             .await?;
@@ -1002,7 +1002,7 @@ mod tests {
         let df = spark.create_dataframe(&data)?;
 
         let res = df
-            .filter(col("name").endswith("e"))
+            .filter(col("name").endswith("ice"))
             .select("name")
             .collect()
             .await?;
@@ -1027,6 +1027,30 @@ mod tests {
 
         let res = df
             .filter(col("name").like("Alice"))
+            .select("name")
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_ilike() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+
+        let data = RecordBatch::try_from_iter(vec![("name", name)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("name").ilike("%Ice"))
             .select("name")
             .collect()
             .await?;

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -650,6 +650,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_func_desc_nulls_first() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+            None,
+        ]));
+
+        let data = RecordBatch::try_new(Arc::new(schema), vec![a.clone()])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .select([col("a")])
+            .sort([col("a").desc_nulls_first()])
+            .collect()
+            .await?;
+
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+
+        let b: ArrayRef = Arc::new(Int64Array::from(vec![
+            None,
+            None,
+            Some(3),
+            Some(2),
+            Some(1),
+        ]));
+
+        let expected = RecordBatch::try_new(Arc::new(schema), vec![b.clone()])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_desc_nulls_last() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+            None,
+        ]));
+
+        let data = RecordBatch::try_new(Arc::new(schema), vec![a.clone()])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .select([col("a")])
+            .sort([col("a").desc_nulls_last()])
+            .collect()
+            .await?;
+
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+
+        let b: ArrayRef = Arc::new(Int64Array::from(vec![
+            Some(3),
+            Some(2),
+            Some(1),
+            None,
+            None,
+        ]));
+
+        let expected = RecordBatch::try_new(Arc::new(schema), vec![b.clone()])?;
+
+        assert_eq!(expected, res);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_func_coalesce() -> Result<(), SparkError> {
         let spark = setup().await;
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1165,51 +1165,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_func_is_null() -> Result<(), SparkError> {
-        let spark = setup().await;
-
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("b", DataType::Int64, true),
-        ]);
-
-        let a: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), None]));
-        let b: ArrayRef = Arc::new(Int64Array::from(vec![None, Some(1)]));
-
-        let data = RecordBatch::try_new(Arc::new(schema), vec![a.clone(), b.clone()])?;
-
-        let df = spark.create_dataframe(&data)?;
-
-        let res = df
-            .select(vec![
-                col("a"),
-                col("b"),
-                col("a").is_null().alias("r1"),
-                col("b").is_null().alias("r2"),
-            ])
-            .collect()
-            .await?;
-
-        let schema = Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("b", DataType::Int64, true),
-            Field::new("r1", DataType::Boolean, false),
-            Field::new("r2", DataType::Boolean, false),
-        ]);
-
-        let c: ArrayRef = Arc::new(BooleanArray::from(vec![false, true]));
-        let d: ArrayRef = Arc::new(BooleanArray::from(vec![true, false]));
-
-        let expected = RecordBatch::try_new(
-            Arc::new(schema),
-            vec![a.clone(), b.clone(), c.clone(), d.clone()],
-        )?;
-
-        assert_eq!(expected, res);
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_func_col_isin() -> Result<(), SparkError> {
         let spark = setup().await;
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1165,6 +1165,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_func_is_null() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+        ]);
+
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), None]));
+        let b: ArrayRef = Arc::new(Int64Array::from(vec![None, Some(1)]));
+
+        let data = RecordBatch::try_new(Arc::new(schema), vec![a.clone(), b.clone()])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .select(vec![
+                col("a"),
+                col("b"),
+                col("a").is_null().alias("r1"),
+                col("b").is_null().alias("r2"),
+            ])
+            .collect()
+            .await?;
+
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+            Field::new("r1", DataType::Boolean, false),
+            Field::new("r2", DataType::Boolean, false),
+        ]);
+
+        let c: ArrayRef = Arc::new(BooleanArray::from(vec![false, true]));
+        let d: ArrayRef = Arc::new(BooleanArray::from(vec![true, false]));
+
+        let expected = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![a.clone(), b.clone(), c.clone(), d.clone()],
+        )?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_func_col_isin() -> Result<(), SparkError> {
         let spark = setup().await;
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -928,7 +928,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_func_substract() -> Result<(), SparkError> {
+    async fn test_func_subtract() -> Result<(), SparkError> {
         let spark = setup().await;
 
         let a: ArrayRef = Arc::new(Int64Array::from(vec![4, 5, 6]));

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -251,7 +251,7 @@ pub fn asc<T: ToLiteralExpr>(col: T) -> Column {
 }
 
 pub fn asc_nulls_first<T: ToLiteralExpr>(col: T) -> Column {
-    Column::from(col.to_literal_expr()).asc_nulls_first()
+    Column::from(col.to_literal_expr()).asc_nulls_first() 
 }
 
 pub fn asc_nulls_last<T: ToLiteralExpr>(col: T) -> Column {
@@ -569,6 +569,13 @@ mod tests {
         assert_eq!(&expected, &rows_col_asc);
         assert_eq!(&expected, &rows_func_asc);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_asc_nulls_first() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        todo!()
     }
 
     #[tokio::test]

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1090,6 +1090,21 @@ mod tests {
     #[tokio::test]
     async fn test_func_eq() -> Result<(), SparkError> {
         let spark = setup().await;
+
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));
+        let b: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 4]));
+
+        let data = RecordBatch::try_from_iter(vec![("a", a), ("b", b)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df.select(col("a").eq("b")).collect().await?;
+
+        let a: ArrayRef = Arc::new(BooleanArray::from(vec![true, true, false]));
+
+        let expected = RecordBatch::try_from_iter(vec![("(a = b)", a)])?;
+
+        assert_eq!(expected, res);
         Ok(())
     }
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1139,4 +1139,9 @@ mod tests {
         assert_eq!(expected, res);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_func_startswith() -> Result<(), SparkError> {
+        todo!()
+    }
 }

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1090,8 +1090,6 @@ mod tests {
     #[tokio::test]
     async fn test_func_eq() -> Result<(), SparkError> {
         let spark = setup().await;
-
-        todo!();
         Ok(())
     }
 

--- a/core/src/functions/mod.rs
+++ b/core/src/functions/mod.rs
@@ -1109,6 +1109,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_func_and() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![14, 23, 16]));
+        let gender: ArrayRef = Arc::new(StringArray::from(vec!["M", "F", "M"]));
+
+        let data =
+            RecordBatch::try_from_iter(vec![("name", name), ("age", age), ("gender", gender)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("age").eq(lit(23)).and(col("gender").eq(lit("F"))))
+            .select(vec!["name", "gender"])
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice"]));
+        let gender: ArrayRef = Arc::new(StringArray::from(vec!["F"]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name), ("gender", gender)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_func_or() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Tom", "Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![14, 23, 16]));
+        let gender: ArrayRef = Arc::new(StringArray::from(vec!["M", "F", "M"]));
+
+        let data =
+            RecordBatch::try_from_iter(vec![("name", name), ("age", age), ("gender", gender)])?;
+
+        let df = spark.create_dataframe(&data)?;
+
+        let res = df
+            .filter(col("age").eq(lit(23)).or(col("age").eq(lit(16))))
+            .select(vec!["name", "age"])
+            .collect()
+            .await?;
+
+        let name: ArrayRef = Arc::new(StringArray::from(vec!["Alice", "Bob"]));
+        let age: ArrayRef = Arc::new(Int64Array::from(vec![23, 16]));
+
+        let expected = RecordBatch::try_from_iter(vec![("name", name), ("age", age)])?;
+
+        assert_eq!(expected, res);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_func_col_isin() -> Result<(), SparkError> {
         let spark = setup().await;
 


### PR DESCRIPTION
# Description

This PR adds the `working-directory` directive to the release workflow, ensuring the correct path is used for operations like comparing the Git tag with the Cargo metadata. As a result, the CI/CD release pipeline now runs successfully and triggers as expected when a tag is pushed.

# Related Issue(s)

- closes #64 

# Documentation

-   No additional documentation changes required