### PR TITLE
Implement File Format Reader/Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,17 @@ The following section outlines some of the larger functionality that are not yet
 
 |DataFrameReader  |API       |Comment                                |
 |------------------|----------|---------------------------------------|
-|csv               |![open]   |                                       |
+|csv               |![done]   |                                       |
 |format            |![done]   |                                       |
-|json              |![open]   |                                       |
+|json              |![done]   |                                       |
 |load              |![done]   |                                       |
 |option            |![done]   |                                       |
 |options           |![done]   |                                       |
-|orc               |![open]   |                                       |
-|parquet           |![open]   |                                       |
+|orc               |![done]   |                                       |
+|parquet           |![done]   |                                       |
 |schema            |![done]   |                                       |
 |table             |![done]   |                                       |
-|text              |![open]   |                                       |
+|text              |![done]   |                                       |
 
 ### DataStreamWriter
 
@@ -373,21 +373,21 @@ required jars
 |DataFrameWriter   |API       |Comment                                |
 |------------------|----------|---------------------------------------|
 |bucketBy          |![done]   |                                       |
-|csv               |          |                                       |
+|csv               |![done]   |                                       |
 |format            |![done]   |                                       |
 |insertInto        |![done]   |                                       |
 |jdbc              |          |                                       |
-|json              |          |                                       |
+|json              |![done]   |                                       |
 |mode              |![done]   |                                       |
 |option            |![done]   |                                       |
 |options           |![done]   |                                       |
-|orc               |          |                                       |
-|parquet           |          |                                       |
+|orc               |![done]   |                                       |
+|parquet           |![done]   |                                       |
 |partitionBy       |          |                                       |
 |save              |![done]   |                                       |
 |saveAsTable       |![done]   |                                       |
 |sortBy            |![done]   |                                       |
-|text              |          |                                       |
+|text              |![done]   |                                       |
 
 ### DataFrameWriterV2
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -100,11 +100,197 @@ impl ConfigOpts for CsvOptions {
     }
 }
 
-/// JsonOptions represents options for configuring
-/// JSON file parsing
-// pub struct JsonOptions {
+/// Configuration options for reading JSON files as a `DataFrame`.
+///
+/// By default, this supports `JSON Lines` (newline-delimited JSON).
+/// For single-record-per-file JSON, set the `multi_line` option to `true`.
+///
+/// If the `schema` option is not specified, the input schema is inferred from the data.
+///
+/// # Options
+///
+/// - `schema`: An optional schema for the JSON data, either as a `StructType` or a DDL string.
+/// - `primitives_as_string`: Treat primitive types as strings.
+/// - `multi_line`: Read multiline JSON files.
+/// - `allow_comments`: Allow comments in JSON files.
+/// - `date_format`: Custom date format.
+/// - `timestamp_format`: Custom timestamp format.
+/// - `encoding`: Character encoding (default is UTF-8).
+/// - `path_glob_filter`: A glob pattern to filter files by their path.
+///
+/// # Example
+///
+/// ```
+/// let options = JsonOptions::new()
+///     .schema("col0 INT, col1 STRING")
+///     .multi_line(true)
+///     .allow_comments(true);
+///
+/// let df = spark.read().json("/path/to/json", options)?;
+/// ```
+pub struct JsonOptions {
+    pub schema: Option<String>,
+    pub primitives_as_string: Option<bool>,
+    pub prefers_decimal: Option<bool>,
+    pub allow_comments: Option<bool>,
+    pub allow_unquoted_field_names: Option<bool>,
+    pub allow_single_quotes: Option<bool>,
+    pub allow_numeric_leading_zero: Option<bool>,
+    pub allow_backslash_escaping_any_character: Option<bool>,
+    pub mode: Option<String>,
+    pub column_name_of_corrupt_record: Option<String>,
+    pub date_format: Option<String>,
+    pub timestamp_format: Option<String>,
+    pub multi_line: Option<bool>,
+    pub allow_unquoted_control_chars: Option<bool>,
+    pub line_sep: Option<String>,
+    pub sampling_ratio: Option<f64>,
+    pub drop_field_if_all_null: Option<bool>,
+    pub encoding: Option<String>,
+    pub locale: Option<String>,
+    pub path_glob_filter: Option<bool>,
+    pub recursive_file_lookup: Option<bool>,
+    pub allow_non_numeric_numbers: Option<bool>,
+}
 
-// }
+impl JsonOptions {
+    pub fn new() -> Self {
+        Self {
+            schema: None,
+            primitives_as_string: None,
+            prefers_decimal: None,
+            allow_comments: None,
+            allow_unquoted_field_names: None,
+            allow_single_quotes: None,
+            allow_numeric_leading_zero: None,
+            allow_backslash_escaping_any_character: None,
+            mode: None,
+            column_name_of_corrupt_record: None,
+            date_format: None,
+            timestamp_format: None,
+            multi_line: None,
+            allow_unquoted_control_chars: None,
+            line_sep: None,
+            sampling_ratio: None,
+            drop_field_if_all_null: None,
+            encoding: None,
+            locale: None,
+            path_glob_filter: None,
+            recursive_file_lookup: None,
+            allow_non_numeric_numbers: None,
+        }
+    }
+
+    pub fn schema(mut self, value: &str) -> Self {
+        self.schema = Some(value.to_string());
+        self
+    }
+
+    pub fn primitives_as_string(mut self, value: bool) -> Self {
+        self.primitives_as_string = Some(value);
+        self
+    }
+
+    pub fn prefers_decimal(mut self, value: bool) -> Self {
+        self.prefers_decimal = Some(value);
+        self
+    }
+
+    pub fn allow_comments(mut self, value: bool) -> Self {
+        self.allow_comments = Some(value);
+        self
+    }
+
+    pub fn allow_unquoted_field_names(mut self, value: bool) -> Self {
+        self.allow_unquoted_field_names = Some(value);
+        self
+    }
+
+    pub fn allow_single_quotes(mut self, value: bool) -> Self {
+        self.allow_single_quotes = Some(value);
+        self
+    }
+
+    pub fn allow_numeric_leading_zero(mut self, value: bool) -> Self {
+        self.allow_numeric_leading_zero = Some(value);
+        self
+    }
+
+    pub fn allow_backslash_escaping_any_character(mut self, value: bool) -> Self {
+        self.allow_backslash_escaping_any_character = Some(value);
+        self
+    }
+
+    pub fn mode(mut self, value: &str) -> Self {
+        self.mode = Some(value.to_string());
+        self
+    }
+
+    pub fn column_name_of_corrupt_record(mut self, value: &str) -> Self {
+        self.column_name_of_corrupt_record = Some(value.to_string());
+        self
+    }
+
+    pub fn date_format(mut self, value: &str) -> Self {
+        self.date_format = Some(value.to_string());
+        self
+    }
+
+    pub fn timestamp_format(mut self, value: &str) -> Self {
+        self.timestamp_format = Some(value.to_string());
+        self
+    }
+
+    pub fn multi_line(mut self, value: bool) -> Self {
+        self.multi_line = Some(value);
+        self
+    }
+
+    pub fn allow_unquoted_control_chars(mut self, value: bool) -> Self {
+        self.allow_unquoted_control_chars = Some(value);
+        self
+    }
+
+    pub fn line_sep(mut self, value: &str) -> Self {
+        self.line_sep = Some(value.to_string());
+        self
+    }
+
+    pub fn sampling_ratio(mut self, value: f64) -> Self {
+        self.sampling_ratio = Some(value);
+        self
+    }
+
+    pub fn drop_field_if_all_null(mut self, value: bool) -> Self {
+        self.drop_field_if_all_null = Some(value);
+        self
+    }
+
+    pub fn encoding(mut self, value: &str) -> Self {
+        self.encoding = Some(value.to_string());
+        self
+    }
+
+    pub fn locale(mut self, value: &str) -> Self {
+        self.locale = Some(value.to_string());
+        self
+    }
+
+    pub fn path_glob_filter(mut self, value: bool) -> Self {
+        self.path_glob_filter = Some(value);
+        self
+    }
+
+    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
+        self.recursive_file_lookup = Some(value);
+        self
+    }
+
+    pub fn allow_non_numeric_numbers(mut self, value: bool) -> Self {
+        self.allow_non_numeric_numbers = Some(value);
+        self
+    }
+}
 
 /// DataFrameReader represents the entrypoint to create a DataFrame
 /// from a specific file format.
@@ -570,6 +756,17 @@ mod tests {
         let rows = df.clone().collect().await?;
 
         assert_eq!(rows.num_rows(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dataframe_read_json_with_options() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let path = ["/opt/spark/work-dir/datasets/employees.json"];
+
+        println!("{:?}", path);
+
         Ok(())
     }
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -1512,19 +1512,20 @@ mod tests {
             .range(None, 1000, 1, Some(16))
             .select_expr(vec!["id AS range_id"]);
 
-        let path = "/tmp/range_id/";
+        let path = "/tmp/csv_with_options_rande_id/";
 
         let mut write_opts = CsvOptions::new();
 
         write_opts.header = Some(true);
         write_opts.null_value = Some("NULL".to_string());
 
-        df.write()
+        let _ = df
+            .write()
             .mode(SaveMode::Overwrite)
             .csv(path, write_opts)
             .await;
 
-        let path = ["/tmp/range_id/"];
+        let path = ["/tmp/csv_with_options_rande_id/"];
 
         let mut read_opts = CsvOptions::new();
 
@@ -1546,7 +1547,7 @@ mod tests {
             .range(None, 1000, 1, Some(16))
             .select_expr(vec!["id AS range_id"]);
 
-        let path = "/tmp/range_id/";
+        let path = "/tmp/json_with_options_rande_id/";
 
         let mut write_opts = JsonOptions::new();
 
@@ -1555,12 +1556,13 @@ mod tests {
         write_opts.allow_unquoted_field_names = Some(false);
         write_opts.primitives_as_string = Some(false);
 
-        df.write()
+        let _ = df
+            .write()
             .mode(SaveMode::Overwrite)
             .json(path, write_opts)
             .await;
 
-        let path = ["/tmp/range_id/"];
+        let path = ["/tmp/json_with_options_rande_id/"];
 
         let read_opts = JsonOptions::new();
 
@@ -1580,16 +1582,17 @@ mod tests {
             .range(None, 1000, 1, Some(16))
             .select_expr(vec!["id AS range_id"]);
 
-        let path = "/tmp/range_id/";
+        let path = "/tmp/orc_with_options_rande_id/";
 
         let write_opts = OrcOptions::new();
 
-        df.write()
+        let _ = df
+            .write()
             .mode(SaveMode::Overwrite)
             .orc(path, write_opts)
             .await;
 
-        let path = ["/tmp/range_id/"];
+        let path = ["/tmp/orc_with_options_rande_id/"];
 
         let mut read_opts = OrcOptions::new();
 
@@ -1613,7 +1616,7 @@ mod tests {
             .range(None, 1000, 1, Some(16))
             .select_expr(vec!["id AS range_id"]);
 
-        let path = "/tmp/range_id/";
+        let path = "/tmp/parquet_with_options_rande_id/";
 
         let mut write_opts = ParquetOptions::new();
 
@@ -1623,12 +1626,13 @@ mod tests {
         // Configure int96 rebase mode (options could be "EXCEPTION", "LEGACY", or "CORRECTED").
         write_opts.int96_rebase_mode = Some("LEGACY".to_string());
 
-        df.write()
+        let _ = df
+            .write()
             .mode(SaveMode::Overwrite)
             .parquet(path, write_opts)
             .await;
 
-        let path = ["/tmp/range_id/"];
+        let path = ["/tmp/parquet_with_options_rande_id/"];
 
         let mut read_opts = ParquetOptions::new();
 
@@ -1658,9 +1662,7 @@ mod tests {
 
         let df = spark.create_dataframe(&data)?;
 
-        df.clone().show(Some(100), None, None).await;
-
-        let path = "/tmp/text_data/";
+        let path = "/tmp/text_with_options_rande_id/";
 
         let mut write_opts = TextOptions::new();
 
@@ -1669,12 +1671,13 @@ mod tests {
         // Note that, in order to use write.text(), the dataframe
         // must have only one column else it will throw error.
         // Hence you need to covert all columns into single column.
-        df.write()
+        let _ = df
+            .write()
             .mode(SaveMode::Overwrite)
             .text(path, write_opts)
             .await;
 
-        let path = ["/tmp/text_data/"];
+        let path = ["/tmp/text_with_options_rande_id/"];
 
         let mut read_opts = TextOptions::new();
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -47,7 +47,34 @@ pub trait ConfigOpts {
     fn to_options(&self) -> HashMap<String, String>;
 }
 
-/// Common file options.
+/// Common file options that are shared across multiple file formats
+/// (e.g., CSV, JSON, ORC, Parquet, Text).
+///
+/// These options allow for file filtering and error handling during
+/// file discovery and processing.
+///
+/// # Fields
+///
+/// - `path_glob_filter`: Optional glob pattern to filter files by path.
+///   This can be used to select specific files within a directory.
+///
+/// - `recursive_file_lookup`: Whether to recursively search for files in
+///   subdirectories. If set to `true`, the reader will search all subdirectories
+///   for matching files.
+///
+/// - `modified_before`: An optional string specifying a cutoff date for filtering
+///   files. Files modified after this date will not be included.
+///
+/// - `modified_after`: An optional string specifying a start date for filtering
+///   files. Only files modified after this date will be included.
+///
+/// - `ignore_corrupt_files`: If set to `true`, the reader will skip corrupt files
+///   instead of throwing an error. This is useful in scenarios where some files
+///   may be malformed.
+///
+/// - `ignore_missing_files`: If set to `true`, missing files (e.g., those filtered out by
+///   the glob pattern) will be ignored instead of causing an error. This is useful when
+///   running in environments where files may be missing intermittently.
 #[derive(Debug, Clone)]
 pub struct CommonFileOptions {
     pub path_glob_filter: Option<String>,
@@ -153,11 +180,8 @@ impl ConfigOpts for CommonFileOptions {
 /// - `empty_value`: Representation of an empty value in the CSV file.
 /// - `locale`: Locale of the CSV file, used for number formatting.
 /// - `line_sep`: Line separator character in the CSV file.
-/// - `path_glob_filter`: Whether to filter files using a glob pattern based on path.
-/// - `recursive_file_lookup`: Whether to recursively look for files in the directory.
-/// - `modified_before`: Filter files modified before this date.
-/// - `modified_after`: Filter files modified after this date.
 /// - `unescaped_quote_handling`: How to handle unescaped quotes in quoted fields. Options are "STOP_AT_CLOSING_QUOTE" and "BACK_TO_DELIMITER".
+/// - `common` - Common file options that are shared across multiple file formats.
 #[derive(Debug, Clone)]
 pub struct CsvOptions {
     pub schema: Option<String>,
@@ -622,13 +646,12 @@ impl ConfigOpts for CsvOptions {
 /// - `drop_field_if_all_null`: Drop fields that are `NULL` in all rows.
 /// - `encoding`: Character encoding (default is `UTF-8`).
 /// - `locale`: Locale for parsing dates and numbers (e.g., `en-US`).
-/// - `path_glob_filter`: A glob pattern to filter files by their path.
-/// - `recursive_file_lookup`: Enable recursive search for files in directories.
 /// - `allow_non_numeric_numbers`: Allow special non-numeric numbers (e.g., `NaN`, `Infinity`).
 /// - `time_zone`: Time zone used for parsing dates and timestamps (e.g., `UTC`, `America/Los_Angeles`).
 /// - `timestamp_ntz_format`: Format for parsing timestamp without time zone (NTZ) values (e.g., `yyyy-MM-dd'T'HH:mm:ss`).
 /// - `enable_datetime_parsing_fallback`: Enable fallback mechanism for datetime parsing if the initial parsing fails.
 /// - `ignore_null_fields`: Ignore `NULL` fields in the JSON structure, treating them as absent.
+/// - `common` - Common file options that are shared across multiple file formats.
 ///
 /// # Example
 /// ```
@@ -984,16 +1007,14 @@ impl ConfigOpts for JsonOptions {
 ///
 /// - `merge_schema`: Merge schemas from all ORC files.
 /// - `path_glob_filter`: A glob pattern to filter files by their path.
-/// - `recursive_file_lookup`: Enable recursive search for files in directories.
-/// - `modified_before`: Only include files modified before a given timestamp.
-/// - `modified_after`: Only include files modified after a given timestamp.
+/// - `common` - Common file options that are shared across multiple file formats.
 ///
 /// # Example
 /// ```
 /// let options = OrcOptions::new()
 ///     .merge_schema(true)
-///     .path_glob_filter("*.orc".to_string())
-///     .recursive_file_lookup(true);
+///     .common.path_glob_filter("*.orc".to_string())
+///     .common.recursive_file_lookup(true);
 ///
 /// let df = spark.read().orc(["/path/to/orc"], options)?;
 /// ```
@@ -1047,19 +1068,16 @@ impl ConfigOpts for OrcOptions {
 /// # Options
 ///
 /// - `merge_schema`: Merge schemas from all Parquet files.
-/// - `path_glob_filter`: A glob pattern to filter files by their path.
-/// - `recursive_file_lookup`: Enable recursive search for files in directories.
-/// - `modified_before`: Only include files modified before a given timestamp.
-/// - `modified_after`: Only include files modified after a given timestamp.
 /// - `datetime_rebase_mode`: Controls how Spark handles rebase of datetime fields.
 /// - `int96_rebase_mode`: Controls how Spark handles rebase of INT96 fields.
-///
+/// - `common` - Common file options that are shared across multiple file formats.
+/// 
 /// # Example
 /// ```
 /// let options = ParquetOptions::new()
 ///     .merge_schema(true)
-///     .path_glob_filter("*.parquet".to_string())
-///     .recursive_file_lookup(true);
+///     .common.path_glob_filter("*.parquet".to_string())
+///     .common.recursive_file_lookup(true);
 ///
 /// let df = spark.read().parquet(["/path/to/parquet"], options)?;
 /// ```
@@ -1139,17 +1157,14 @@ impl ConfigOpts for ParquetOptions {
 ///
 /// - `whole_text`: Read the entire file as a single string.
 /// - `line_sep`: Define the line separator (default is `\n`).
-/// - `path_glob_filter`: A glob pattern to filter files by their path.
-/// - `recursive_file_lookup`: Enable recursive search for files in directories.
-/// - `modified_before`: Only include files modified before a given timestamp.
-/// - `modified_after`: Only include files modified after a given timestamp.
+/// - `common` - Common file options that are shared across multiple file formats.
 ///
 /// # Example
 /// ```
 /// let options = TextOptions::new()
 ///     .whole_text(true)
 ///     .line_sep("\n".to_string())
-///     .path_glob_filter("*.txt".to_string());
+///     .common.path_glob_filter("*.txt".to_string());
 ///
 /// let df = spark.read().text(["/path/to/text"], options)?;
 /// ```

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -41,7 +41,7 @@ impl ToSchema for &str {
 
 /// A trait used to handle individual options via [option]
 /// and bulk options via [options]
-/// 
+///
 /// This sets multiple options at once using a HashMap
 pub trait ConfigOpts {
     fn to_options(&self) -> HashMap<String, String>;
@@ -539,6 +539,26 @@ mod tests {
 
         let rows = df.collect().await?;
 
+        assert_eq!(rows.num_rows(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dataframe_read_csv_with_options() -> Result<(), SparkError> {
+        let spark = setup().await;
+
+        let path = "/opt/spark/work-dir/datasets/people.csv";
+
+        let mut opts = CsvOptions::new();
+
+        opts.header = Some(true);
+        opts.delimiter = Some(b';');
+        opts.null_value = Some("NULL".to_string());
+
+        let df = spark.read().csv(path, opts)?;
+
+        let rows = df.clone().collect().await?;
+    
         assert_eq!(rows.num_rows(), 2);
         Ok(())
     }

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -1070,8 +1070,8 @@ impl ConfigOpts for OrcOptions {
 /// - `merge_schema`: Merge schemas from all Parquet files.
 /// - `datetime_rebase_mode`: Controls how Spark handles rebase of datetime fields.
 /// - `int96_rebase_mode`: Controls how Spark handles rebase of INT96 fields.
-/// - `common` - Common file options that are shared across multiple file formats.
-/// 
+/// - `common`: Common file options that are shared across multiple file formats.
+///
 /// # Example
 /// ```
 /// let options = ParquetOptions::new()

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -47,6 +47,71 @@ pub trait ConfigOpts {
     fn to_options(&self) -> HashMap<String, String>;
 }
 
+/// Common file options.
+#[derive(Debug, Clone)]
+pub struct CommonFileOptions {
+    pub path_glob_filter: Option<String>,
+    pub recursive_file_lookup: Option<bool>,
+    pub modified_before: Option<String>,
+    pub modified_after: Option<String>,
+    pub ignore_corrupt_files: Option<bool>,
+    pub ignore_missing_files: Option<bool>,
+}
+
+impl CommonFileOptions {
+    pub fn new() -> Self {
+        Self {
+            path_glob_filter: None,
+            recursive_file_lookup: Some(false),
+            modified_before: None,
+            modified_after: None,
+            ignore_corrupt_files: None,
+            ignore_missing_files: None,
+        }
+    }
+}
+
+impl ConfigOpts for CommonFileOptions {
+    fn to_options(&self) -> HashMap<String, String> {
+        let mut options = HashMap::new();
+
+        if let Some(path_glob_filter) = &self.path_glob_filter {
+            options.insert("pathGlobFilter".to_string(), path_glob_filter.clone());
+        }
+
+        if let Some(recursive_file_lookup) = self.recursive_file_lookup {
+            options.insert(
+                "recursiveFileLookup".to_string(),
+                recursive_file_lookup.to_string(),
+            );
+        }
+
+        if let Some(modified_before) = &self.modified_before {
+            options.insert("modifiedBefore".to_string(), modified_before.clone());
+        }
+
+        if let Some(modified_after) = &self.modified_after {
+            options.insert("modifiedAfter".to_string(), modified_after.clone());
+        }
+
+        if let Some(ignore_corrupt_files) = self.ignore_corrupt_files {
+            options.insert(
+                "ignoreCorruptFiles".to_string(),
+                ignore_corrupt_files.to_string(),
+            );
+        }
+
+        if let Some(ignore_missing_files) = self.ignore_missing_files {
+            options.insert(
+                "ignoreMissingFiles".to_string(),
+                ignore_missing_files.to_string(),
+            );
+        }
+
+        options
+    }
+}
+
 /// A struct that represents options for configuring CSV file parsing.
 ///
 /// `CsvOptions` provides various settings to customize the reading of CSV files.
@@ -129,11 +194,8 @@ pub struct CsvOptions {
     pub empty_value: Option<String>,
     pub locale: Option<String>,
     pub line_sep: Option<String>,
-    pub path_glob_filter: Option<String>,
-    pub recursive_file_lookup: Option<bool>,
-    pub modified_before: Option<String>,
-    pub modified_after: Option<String>,
     pub unescaped_quote_handling: Option<String>,
+    pub common: CommonFileOptions,
 }
 
 impl CsvOptions {
@@ -172,12 +234,9 @@ impl CsvOptions {
             empty_value: None,
             locale: None,
             line_sep: None,
-            path_glob_filter: None,
-            recursive_file_lookup: None,
-            modified_before: None,
-            modified_after: None,
             unescaped_quote_handling: None,
             escape_quotes: None,
+            common: CommonFileOptions::new(),
         }
     }
 
@@ -343,26 +402,6 @@ impl CsvOptions {
 
     pub fn line_sep(mut self, value: &str) -> Self {
         self.line_sep = Some(value.to_string());
-        self
-    }
-
-    pub fn path_glob_filter(mut self, value: &str) -> Self {
-        self.path_glob_filter = Some(value.to_string());
-        self
-    }
-
-    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
-        self.recursive_file_lookup = Some(value);
-        self
-    }
-
-    pub fn modified_before(mut self, value: &str) -> Self {
-        self.modified_before = Some(value.to_string());
-        self
-    }
-
-    pub fn modified_after(mut self, value: &str) -> Self {
-        self.modified_after = Some(value.to_string());
         self
     }
 
@@ -537,25 +576,6 @@ impl ConfigOpts for CsvOptions {
             options.insert("lineSep".to_string(), line_sep.to_string());
         }
 
-        if let Some(path_glob_filter) = &self.path_glob_filter {
-            options.insert("pathGlobFilter".to_string(), path_glob_filter.to_string());
-        }
-
-        if let Some(recursive_file_lookup) = self.recursive_file_lookup {
-            options.insert(
-                "recursiveFileLookup".to_string(),
-                recursive_file_lookup.to_string(),
-            );
-        }
-
-        if let Some(modified_before) = &self.modified_before {
-            options.insert("modifiedBefore".to_string(), modified_before.to_string());
-        }
-
-        if let Some(modified_after) = &self.modified_after {
-            options.insert("modifiedAfter".to_string(), modified_after.to_string());
-        }
-
         if let Some(unescaped_quote_handling) = &self.unescaped_quote_handling {
             options.insert(
                 "unescapedQuoteHandling".to_string(),
@@ -566,6 +586,8 @@ impl ConfigOpts for CsvOptions {
         if let Some(escape_quotes) = self.escape_quotes {
             options.insert("escapeQuotes".to_string(), escape_quotes.to_string());
         }
+
+        options.extend(self.common.to_options());
 
         options
     }
@@ -642,13 +664,12 @@ pub struct JsonOptions {
     pub drop_field_if_all_null: Option<bool>,
     pub encoding: Option<String>,
     pub locale: Option<String>,
-    pub path_glob_filter: Option<String>,
-    pub recursive_file_lookup: Option<bool>,
     pub allow_non_numeric_numbers: Option<bool>,
     pub time_zone: Option<String>,
     pub timestamp_ntz_format: Option<String>,
     pub enable_datetime_parsing_fallback: Option<bool>,
     pub ignore_null_fields: Option<bool>,
+    pub common: CommonFileOptions,
 }
 
 impl JsonOptions {
@@ -674,13 +695,12 @@ impl JsonOptions {
             drop_field_if_all_null: None,
             encoding: None,
             locale: None,
-            path_glob_filter: None,
-            recursive_file_lookup: None,
             allow_non_numeric_numbers: None,
             time_zone: None,
             timestamp_ntz_format: None,
             enable_datetime_parsing_fallback: None,
             ignore_null_fields: None,
+            common: CommonFileOptions::new(),
         }
     }
 
@@ -776,16 +796,6 @@ impl JsonOptions {
 
     pub fn locale(mut self, value: &str) -> Self {
         self.locale = Some(value.to_string());
-        self
-    }
-
-    pub fn path_glob_filter(mut self, value: &str) -> Self {
-        self.path_glob_filter = Some(value.to_string());
-        self
-    }
-
-    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
-        self.recursive_file_lookup = Some(value);
         self
     }
 
@@ -930,17 +940,6 @@ impl ConfigOpts for JsonOptions {
             options.insert("locale".to_string(), locale.clone());
         }
 
-        if let Some(path_glob_filter) = &self.path_glob_filter {
-            options.insert("pathGlobFilter".to_string(), path_glob_filter.to_string());
-        }
-
-        if let Some(recursive_file_lookup) = self.recursive_file_lookup {
-            options.insert(
-                "recursiveFileLookup".to_string(),
-                recursive_file_lookup.to_string(),
-            );
-        }
-
         if let Some(allow_non_numeric_numbers) = self.allow_non_numeric_numbers {
             options.insert(
                 "allowNonNumericNumbers".to_string(),
@@ -973,6 +972,8 @@ impl ConfigOpts for JsonOptions {
             );
         }
 
+        options.extend(self.common.to_options());
+
         options
     }
 }
@@ -1000,10 +1001,7 @@ impl ConfigOpts for JsonOptions {
 pub struct OrcOptions {
     pub compression: Option<String>,
     pub merge_schema: Option<bool>,
-    pub path_glob_filter: Option<String>,
-    pub recursive_file_lookup: Option<bool>,
-    pub modified_before: Option<String>,
-    pub modified_after: Option<String>,
+    pub common: CommonFileOptions,
 }
 
 impl OrcOptions {
@@ -1011,10 +1009,7 @@ impl OrcOptions {
         OrcOptions {
             compression: Some("snappy".to_string()),
             merge_schema: None,
-            path_glob_filter: None,
-            recursive_file_lookup: None,
-            modified_before: None,
-            modified_after: None,
+            common: CommonFileOptions::new(),
         }
     }
 
@@ -1025,26 +1020,6 @@ impl OrcOptions {
 
     pub fn merge_schema(mut self, value: bool) -> Self {
         self.merge_schema = Some(value);
-        self
-    }
-
-    pub fn path_glob_filter(mut self, value: &str) -> Self {
-        self.path_glob_filter = Some(value.to_string());
-        self
-    }
-
-    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
-        self.recursive_file_lookup = Some(value);
-        self
-    }
-
-    pub fn modified_before(mut self, value: &str) -> Self {
-        self.modified_before = Some(value.to_string());
-        self
-    }
-
-    pub fn modified_after(mut self, value: &str) -> Self {
-        self.modified_after = Some(value.to_string());
         self
     }
 }
@@ -1061,24 +1036,7 @@ impl ConfigOpts for OrcOptions {
             options.insert("mergeSchema".to_string(), merge_schema.to_string());
         }
 
-        if let Some(path_glob_filter) = &self.path_glob_filter {
-            options.insert("pathGlobFilter".to_string(), path_glob_filter.to_string());
-        }
-
-        if let Some(recursive_file_lookup) = self.recursive_file_lookup {
-            options.insert(
-                "recursiveFileLookup".to_string(),
-                recursive_file_lookup.to_string(),
-            );
-        }
-
-        if let Some(modified_before) = &self.modified_before {
-            options.insert("modifiedBefore".to_string(), modified_before.to_string());
-        }
-
-        if let Some(modified_after) = &self.modified_after {
-            options.insert("modifiedAfter".to_string(), modified_after.to_string());
-        }
+        options.extend(self.common.to_options());
 
         options
     }
@@ -1109,12 +1067,9 @@ impl ConfigOpts for OrcOptions {
 pub struct ParquetOptions {
     pub compression: Option<String>,
     pub merge_schema: Option<bool>,
-    pub path_glob_filter: Option<String>,
-    pub recursive_file_lookup: Option<bool>,
-    pub modified_before: Option<String>,
-    pub modified_after: Option<String>,
     pub datetime_rebase_mode: Option<String>,
     pub int96_rebase_mode: Option<String>,
+    pub common: CommonFileOptions,
 }
 
 impl ParquetOptions {
@@ -1122,12 +1077,9 @@ impl ParquetOptions {
         Self {
             compression: Some("snappy".to_string()),
             merge_schema: None,
-            path_glob_filter: None,
-            recursive_file_lookup: None,
-            modified_before: None,
-            modified_after: None,
             datetime_rebase_mode: None,
             int96_rebase_mode: None,
+            common: CommonFileOptions::new(),
         }
     }
 
@@ -1138,26 +1090,6 @@ impl ParquetOptions {
 
     pub fn merge_schema(mut self, value: bool) -> Self {
         self.merge_schema = Some(value);
-        self
-    }
-
-    pub fn path_glob_filter(mut self, value: &str) -> Self {
-        self.path_glob_filter = Some(value.to_string());
-        self
-    }
-
-    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
-        self.recursive_file_lookup = Some(value);
-        self
-    }
-
-    pub fn modified_before(mut self, value: &str) -> Self {
-        self.modified_before = Some(value.to_string());
-        self
-    }
-
-    pub fn modified_after(mut self, value: &str) -> Self {
-        self.modified_after = Some(value.to_string());
         self
     }
 
@@ -1184,25 +1116,6 @@ impl ConfigOpts for ParquetOptions {
             options.insert("mergeSchema".to_string(), merge_schema.to_string());
         }
 
-        if let Some(path_glob_filter) = &self.path_glob_filter {
-            options.insert("pathGlobFilter".to_string(), path_glob_filter.to_string());
-        }
-
-        if let Some(recursive_file_lookup) = self.recursive_file_lookup {
-            options.insert(
-                "recursiveFileLookup".to_string(),
-                recursive_file_lookup.to_string(),
-            );
-        }
-
-        if let Some(modified_before) = &self.modified_before {
-            options.insert("modifiedBefore".to_string(), modified_before.to_string());
-        }
-
-        if let Some(modified_after) = &self.modified_after {
-            options.insert("modifiedAfter".to_string(), modified_after.to_string());
-        }
-
         if let Some(datetime_rebase_mode) = &self.datetime_rebase_mode {
             options.insert(
                 "datetimeRebaseMode".to_string(),
@@ -1213,6 +1126,8 @@ impl ConfigOpts for ParquetOptions {
         if let Some(int96_rebase_mode) = &self.int96_rebase_mode {
             options.insert("int96RebaseMode".to_string(), int96_rebase_mode.to_string());
         }
+
+        options.extend(self.common.to_options());
 
         options
     }
@@ -1242,10 +1157,7 @@ impl ConfigOpts for ParquetOptions {
 pub struct TextOptions {
     pub whole_text: Option<bool>,
     pub line_sep: Option<String>,
-    pub path_glob_filter: Option<String>,
-    pub recursive_file_lookup: Option<bool>,
-    pub modified_before: Option<String>,
-    pub modified_after: Option<String>,
+    pub common: CommonFileOptions,
 }
 
 impl TextOptions {
@@ -1253,10 +1165,7 @@ impl TextOptions {
         Self {
             whole_text: None,
             line_sep: None,
-            path_glob_filter: None,
-            recursive_file_lookup: None,
-            modified_before: None,
-            modified_after: None,
+            common: CommonFileOptions::new(),
         }
     }
 
@@ -1267,26 +1176,6 @@ impl TextOptions {
 
     pub fn line_sep(mut self, value: &str) -> Self {
         self.line_sep = Some(value.to_string());
-        self
-    }
-
-    pub fn path_glob_filter(mut self, value: &str) -> Self {
-        self.path_glob_filter = Some(value.to_string());
-        self
-    }
-
-    pub fn recursive_file_lookup(mut self, value: bool) -> Self {
-        self.recursive_file_lookup = Some(value);
-        self
-    }
-
-    pub fn modified_before(mut self, value: &str) -> Self {
-        self.modified_before = Some(value.to_string());
-        self
-    }
-
-    pub fn modified_after(mut self, value: &str) -> Self {
-        self.modified_after = Some(value.to_string());
         self
     }
 }
@@ -1303,24 +1192,7 @@ impl ConfigOpts for TextOptions {
             options.insert("lineSep".to_string(), line_sep.to_string());
         }
 
-        if let Some(path_glob_filter) = &self.path_glob_filter {
-            options.insert("pathGlobFilter".to_string(), path_glob_filter.to_string());
-        }
-
-        if let Some(recursive_file_lookup) = &self.recursive_file_lookup {
-            options.insert(
-                "recursiveFileLookup".to_string(),
-                recursive_file_lookup.to_string(),
-            );
-        }
-
-        if let Some(modified_before) = &self.modified_before {
-            options.insert("modifiedBefore".to_string(), modified_before.to_string());
-        }
-
-        if let Some(modified_after) = &self.modified_after {
-            options.insert("modifiedAfter".to_string(), modified_after.to_string());
-        }
+        options.extend(self.common.to_options());
 
         options
     }
@@ -1919,8 +1791,8 @@ mod tests {
 
         opts.compression = Some("snappy".to_string());
         opts.merge_schema = Some(true);
-        opts.path_glob_filter = Some("*.orc".to_string());
-        opts.recursive_file_lookup = Some(true);
+        opts.common.path_glob_filter = Some("*.orc".to_string());
+        opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().orc(path, opts)?;
 
@@ -1939,8 +1811,8 @@ mod tests {
         let mut opts = ParquetOptions::new();
 
         opts.compression = Some("snappy".to_string());
-        opts.path_glob_filter = Some("*.parquet".to_string());
-        opts.recursive_file_lookup = Some(true);
+        opts.common.path_glob_filter = Some("*.parquet".to_string());
+        opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().parquet(path, opts)?;
 
@@ -1961,8 +1833,8 @@ mod tests {
         // If true, read each file from input path(s) as a single row.
         opts.whole_text = Some(false);
         opts.line_sep = Some("\n".to_string());
-        opts.path_glob_filter = Some("*.txt".to_string());
-        opts.recursive_file_lookup = Some(true);
+        opts.common.path_glob_filter = Some("*.txt".to_string());
+        opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().text(path, opts)?;
 
@@ -2172,8 +2044,8 @@ mod tests {
         let mut read_opts = OrcOptions::new();
 
         read_opts.merge_schema = Some(true);
-        read_opts.path_glob_filter = Some("*.orc".to_string());
-        read_opts.recursive_file_lookup = Some(true);
+        read_opts.common.path_glob_filter = Some("*.orc".to_string());
+        read_opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().orc(path, read_opts)?;
 
@@ -2212,8 +2084,8 @@ mod tests {
         let mut read_opts = ParquetOptions::new();
 
         read_opts.merge_schema = Some(false);
-        read_opts.path_glob_filter = Some("*.parquet".to_string());
-        read_opts.recursive_file_lookup = Some(true);
+        read_opts.common.path_glob_filter = Some("*.parquet".to_string());
+        read_opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().parquet(path, read_opts)?;
 
@@ -2258,8 +2130,8 @@ mod tests {
 
         read_opts.whole_text = Some(true);
         read_opts.line_sep = Some("\n".to_string());
-        read_opts.path_glob_filter = Some("*.txt".to_string());
-        read_opts.recursive_file_lookup = Some(true);
+        read_opts.common.path_glob_filter = Some("*.txt".to_string());
+        read_opts.common.recursive_file_lookup = Some(true);
 
         let df = spark.read().text(path, read_opts)?;
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -887,6 +887,7 @@ impl DataFrameReader {
         Ok(DataFrame::new(self.spark_session, logical_plan))
     }
 
+    /// Reads data from CSV files with the specified options.
     pub fn csv<'a, C, I>(mut self, paths: I, config: C) -> Result<DataFrame, SparkError>
     where
         C: ConfigOpts,
@@ -897,6 +898,7 @@ impl DataFrameReader {
         self.load(paths)
     }
 
+    /// Reads data from JSON files with the specified options.
     pub fn json<'a, C, I>(mut self, paths: I, config: C) -> Result<DataFrame, SparkError>
     where
         C: ConfigOpts,
@@ -907,6 +909,7 @@ impl DataFrameReader {
         self.load(paths)
     }
 
+    /// Reads data from ORC files with the specified options.
     pub fn orc<'a, C, I>(mut self, paths: I, config: C) -> Result<DataFrame, SparkError>
     where
         C: ConfigOpts,
@@ -917,6 +920,7 @@ impl DataFrameReader {
         self.load(paths)
     }
 
+    /// Reads data from Parquet files with the specified options.
     pub fn parquet<'a, C, I>(mut self, paths: I, config: C) -> Result<DataFrame, SparkError>
     where
         C: ConfigOpts,
@@ -927,6 +931,7 @@ impl DataFrameReader {
         self.load(paths)
     }
 
+    /// Reads data from text files with the specified options.
     pub fn text<'a, C, I>(mut self, paths: I, config: C) -> Result<DataFrame, SparkError>
     where
         C: ConfigOpts,
@@ -1108,30 +1113,35 @@ impl DataFrameWriter {
         self.save_table(table_name, 2).await
     }
 
+    /// Writes the DataFrame to a CSV file with the specified options.
     pub async fn csv<C: ConfigOpts>(mut self, path: &str, config: C) -> Result<(), SparkError> {
         self.format = Some("csv".to_string());
         self.write_options.extend(config.to_options());
         self.save(path).await
     }
 
+    /// Writes the DataFrame to a JSON file with the specified options.
     pub async fn json<C: ConfigOpts>(mut self, path: &str, config: C) -> Result<(), SparkError> {
         self.format = Some("json".to_string());
         self.write_options.extend(config.to_options());
         self.save(path).await
     }
 
+    /// Writes the DataFrame to an ORC file with the specified options.
     pub async fn orc<C: ConfigOpts>(mut self, path: &str, config: C) -> Result<(), SparkError> {
         self.format = Some("orc".to_string());
         self.write_options.extend(config.to_options());
         self.save(path).await
     }
 
+    /// Writes the DataFrame to a Parquet file with the specified options.
     pub async fn parquet<C: ConfigOpts>(mut self, path: &str, config: C) -> Result<(), SparkError> {
         self.format = Some("parquet".to_string());
         self.write_options.extend(config.to_options());
         self.save(path).await
     }
 
+    /// Writes the DataFrame to a text file with the specified options.
     pub async fn text<C: ConfigOpts>(mut self, path: &str, config: C) -> Result<(), SparkError> {
         self.format = Some("text".to_string());
         self.write_options.extend(config.to_options());
@@ -1241,6 +1251,7 @@ impl DataFrameWriterV2 {
 mod tests {
 
     use super::*;
+
     use std::sync::Arc;
 
     use crate::errors::SparkError;
@@ -1470,7 +1481,6 @@ mod tests {
         let records = df.select(vec![col("range_id")]).collect().await?;
 
         assert_eq!(records.num_rows(), 1000);
-
         Ok(())
     }
 

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -49,33 +49,93 @@ pub trait ConfigOpts {
 
 /// A struct that represents options for configuring
 /// CsvOptions for CSV file parsing
+#[derive(Debug, Clone)]
 pub struct CsvOptions {
+    pub path: Option<String>,
+    pub schema: Option<String>,
+    pub sep: Option<String>,
+    pub encoding: Option<String>,
+    pub quote: Option<String>,
+    pub escape: Option<String>,
+    pub comment: Option<String>,
     pub header: Option<bool>,
-    pub delimiter: Option<u8>,
+    pub infer_schema: Option<bool>,
+    pub ignore_leading_white_space: Option<bool>,
+    pub ignore_trailing_white_space: Option<bool>,
     pub null_value: Option<String>,
+    pub nan_value: Option<String>,
+    pub positive_inf: Option<String>,
+    pub negative_inf: Option<String>,
+    pub date_format: Option<String>,
+    pub timestamp_format: Option<String>,
+    pub max_columns: Option<i32>,
+    pub max_chars_per_column: Option<i32>,
+    pub max_malformed_log_per_partition: Option<i32>,
+    pub mode: Option<String>,
+    pub column_name_of_corrupt_record: Option<String>,
+    pub multi_line: Option<bool>,
+    pub char_to_escape_quote_escaping: Option<String>,
+    pub sampling_ratio: Option<f64>,
+    pub enforce_schema: Option<bool>,
+    pub empty_value: Option<String>,
+    pub locale: Option<String>,
+    pub line_sep: Option<String>,
+    pub path_glob_filter: Option<bool>,
+    pub recursive_file_lookup: Option<bool>,
+    pub modified_before: Option<String>,
+    pub modified_after: Option<String>,
+    pub unescaped_quote_handling: Option<String>,
 }
 
 impl CsvOptions {
     pub fn new() -> Self {
         Self {
+            path: None,
+            schema: None,
+            sep: None,
+            encoding: None,
+            quote: None,
+            escape: None,
+            comment: None,
             header: None,
-            delimiter: None,
+            infer_schema: None,
+            ignore_leading_white_space: None,
+            ignore_trailing_white_space: None,
             null_value: None,
+            nan_value: None,
+            positive_inf: None,
+            negative_inf: None,
+            date_format: None,
+            timestamp_format: None,
+            max_columns: None,
+            max_chars_per_column: None,
+            max_malformed_log_per_partition: None,
+            mode: None,
+            column_name_of_corrupt_record: None,
+            multi_line: None,
+            char_to_escape_quote_escaping: None,
+            sampling_ratio: None,
+            enforce_schema: None,
+            empty_value: None,
+            locale: None,
+            line_sep: None,
+            path_glob_filter: None,
+            recursive_file_lookup: None,
+            modified_before: None,
+            modified_after: None,
+            unescaped_quote_handling: None,
         }
     }
+
+    // Missing delimeter option?
 
     pub fn header(mut self, value: bool) -> Self {
         self.header = Some(value);
         self
     }
 
-    pub fn delimiter(mut self, value: u8) -> Self {
-        self.delimiter = Some(value);
-        self
-    }
-
     pub fn null_value(mut self, value: &str) -> Self {
-        self.null_value = Some(value.to_string());
+        self.null_value = Some(value.to_strinNone);
         self
     }
 }

--- a/core/src/readwriter.rs
+++ b/core/src/readwriter.rs
@@ -47,6 +47,8 @@ pub trait ConfigOpts {
     fn to_options(&self) -> HashMap<String, String>;
 }
 
+/// CsvOptions represents options for configuring
+/// CSV file parsing
 pub struct CsvOptions {
     pub header: Option<bool>,
     pub delimiter: Option<u8>,


### PR DESCRIPTION
# Description

This pull request enables DataFrames to be **read from and written to various file formats** (CSV, JSON, ORC, Parquet) using a **set of predefined options** implemented via the `ConfigOpts` trait. Key changes include:

-   **DataFrameWriter:**
    
    -   Implemented functionality to write DataFrames to `csv`, `json`, `orc`, `parquet` and `text` formats.
    -   Added support for configuration options for various file formats (i.e `csv`, `json`, `orc`, `parquet` and `text`).
    -   `ConfigOpts` trait implemented for `JsonOptions`, `OrcOptions`, and `ParquetOptions`.
    -   Unit tests added to validate configuration options, similar to `TableOptions` tests in DataFusion.
    
-   **DataFrameReader:**
    
    -   Enabled reading DataFrames from `csv`, `json`, `orc`, `parquet` and `text` formats.
    -   Supported predefined reading options using the `ConfigOpts` trait for flexible configuration.
    -   Added advanced options like schema merging and recursive file lookup for Parquet files.
    -   Developed tests ensuring correct functionality of the `DataFrameReader` configurations and file parsing.

# Related Issue(s)

-   Closes #54 

# Documentation

-   [PySpark IO](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/io.html)
-   [DataFusion](https://docs.rs/datafusion/latest/datafusion/common/config/index.html)