### PR TITLE
feat(reattach): Add reattach & release logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     hooks:
       - id: fmt
       - id: cargo-check
-      # - id: clippy
+      - id: clippy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     hooks:
       - id: fmt
       - id: cargo-check
-      - id: clippy
+      # - id: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1153,15 +1153,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1170,21 +1170,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2604,7 +2604,9 @@ dependencies = [
  "chrono",
  "datafusion",
  "futures",
+ "futures-util",
  "getrandom",
+ "http-body 0.4.6",
  "polars",
  "polars-arrow",
  "prost",
@@ -2615,6 +2617,7 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build",
  "tonic-web-wasm-client",
+ "tower 0.5.1",
  "url",
  "uuid",
 ]
@@ -2911,7 +2914,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2995,16 +2998,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ tonic = { version ="0.11", default-features = false }
 tonic-web-wasm-client = { version = "0.6" }
 
 tokio = { version = "1.40", default-features = false, features = ["macros"] }
+tower = { version = "0.5", features = ["timeout", "retry"] }
+
+futures-util = { version = "0.3.31" }
+
+http-body = { version = "0.4.6" }
 
 arrow = { version = "53", features = ["prettyprint"] }
 arrow-ipc = { version = "53" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,12 @@ include = [
 tonic = { workspace = true, default-features = false, optional = true }
 tonic-web-wasm-client = { workspace = true, optional = true }
 
+tower = { workspace = true }
 tokio = { workspace = true, optional = true }
+
+futures-util = { workspace = true }
+
+http-body = { workspace = true }
 
 arrow = { workspace = true }
 arrow-ipc = { workspace = true }

--- a/core/src/client/builder.rs
+++ b/core/src/client/builder.rs
@@ -1,0 +1,251 @@
+use std::collections::HashMap;
+use std::env;
+use std::str::FromStr;
+
+use crate::errors::SparkError;
+use tonic::metadata::MetadataMap;
+
+use url::Url;
+
+use uuid::Uuid;
+
+use super::middleware::metadata_builder;
+
+type Host = String;
+type Port = u16;
+type UrlParse = (Host, Port, Option<HashMap<String, String>>);
+
+/// ChannelBuilder validates a connection string
+/// based on the requirements from [Spark Documentation](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md)
+#[derive(Clone, Debug)]
+pub struct ChannelBuilder {
+    pub(super) host: Host,
+    pub(super) port: Port,
+    pub(super) session_id: Uuid,
+    pub(super) token: Option<String>,
+    pub(super) user_id: Option<String>,
+    pub(super) user_agent: Option<String>,
+    pub(super) use_ssl: bool,
+    pub(super) headers: Option<MetadataMap>,
+}
+
+impl Default for ChannelBuilder {
+    fn default() -> Self {
+        let connection = match env::var("SPARK_REMOTE") {
+            Ok(conn) => conn.to_string(),
+            Err(_) => "sc://localhost:15002".to_string(),
+        };
+
+        ChannelBuilder::create(&connection).unwrap()
+    }
+}
+
+impl ChannelBuilder {
+    pub fn new() -> Self {
+        ChannelBuilder::default()
+    }
+
+    pub fn endpoint(&self) -> String {
+        let scheme = if cfg!(feature = "tls") {
+            "https"
+        } else {
+            "http"
+        };
+
+        format!("{}://{}:{}", scheme, self.host, self.port)
+    }
+
+    pub fn token(&self) -> Option<String> {
+        self.token.to_owned()
+    }
+
+    pub fn headers(&self) -> Option<MetadataMap> {
+        self.headers.to_owned()
+    }
+
+    fn create_user_agent(user_agent: Option<&str>) -> Option<String> {
+        let user_agent = user_agent.unwrap_or("_SPARK_CONNECT_RUST");
+        let pkg_version = env!("CARGO_PKG_VERSION");
+        let os = env::consts::OS.to_lowercase();
+
+        Some(format!(
+            "{} os/{} spark_connect_rs/{}",
+            user_agent, os, pkg_version
+        ))
+    }
+
+    fn create_user_id(user_id: Option<&str>) -> Option<String> {
+        match user_id {
+            Some(user_id) => Some(user_id.to_string()),
+            None => match env::var("USER") {
+                Ok(user) => Some(user),
+                Err(_) => None,
+            },
+        }
+    }
+
+    pub fn parse_connection_string(connection: &str) -> Result<UrlParse, SparkError> {
+        let url = Url::parse(connection).map_err(|_| {
+            SparkError::InvalidConnectionUrl("Failed to parse the connection URL".to_string())
+        })?;
+
+        if url.scheme() != "sc" {
+            return Err(SparkError::InvalidConnectionUrl(
+                "The URL must start with 'sc://'. Please update the URL to follow the correct format, e.g., 'sc://hostname:port'".to_string(),
+            ));
+        };
+
+        let host = url
+            .host_str()
+            .ok_or_else(|| {
+                SparkError::InvalidConnectionUrl(
+                    "The hostname must not be empty. Please update
+                    the URL to follow the correct format, e.g., 'sc://hostname:port'."
+                        .to_string(),
+                )
+            })?
+            .to_string();
+
+        let port = url.port().ok_or_else(|| {
+            SparkError::InvalidConnectionUrl(
+                "The port must not be empty. Please update
+                    the URL to follow the correct format, e.g., 'sc://hostname:port'."
+                    .to_string(),
+            )
+        })?;
+
+        let headers = ChannelBuilder::parse_headers(url);
+
+        Ok((host, port, headers))
+    }
+
+    pub fn parse_headers(url: Url) -> Option<HashMap<String, String>> {
+        let path: Vec<&str> = url
+            .path()
+            .split(';')
+            .filter(|&pair| (pair != "/") & (!pair.is_empty()))
+            .collect();
+
+        if path.is_empty() || (path.len() == 1 && (path[0].is_empty() || path[0] == "/")) {
+            return None;
+        }
+
+        let headers: HashMap<String, String> = path
+            .iter()
+            .copied()
+            .map(|pair| {
+                let mut parts = pair.splitn(2, '=');
+                (
+                    parts.next().unwrap_or("").to_string(),
+                    parts.next().unwrap_or("").to_string(),
+                )
+            })
+            .collect();
+
+        if headers.is_empty() {
+            return None;
+        }
+
+        Some(headers)
+    }
+
+    /// Create and validate a connnection string
+    #[allow(unreachable_code)]
+    pub fn create(connection: &str) -> Result<ChannelBuilder, SparkError> {
+        let (host, port, headers) = ChannelBuilder::parse_connection_string(connection)?;
+
+        let mut channel_builder = ChannelBuilder {
+            host,
+            port,
+            session_id: Uuid::new_v4(),
+            token: None,
+            user_id: ChannelBuilder::create_user_id(None),
+            user_agent: ChannelBuilder::create_user_agent(None),
+            use_ssl: false,
+            headers: None,
+        };
+
+        if let Some(mut headers) = headers {
+            channel_builder.user_id = headers
+                .remove("user_id")
+                .map(|user_id| ChannelBuilder::create_user_id(Some(&user_id)))
+                .unwrap_or_else(|| ChannelBuilder::create_user_id(None));
+
+            channel_builder.user_agent = headers
+                .remove("user_agent")
+                .map(|user_agent| ChannelBuilder::create_user_agent(Some(&user_agent)))
+                .unwrap_or_else(|| ChannelBuilder::create_user_agent(None));
+
+            if let Some(token) = headers.remove("token") {
+                channel_builder.token = Some(format!("Bearer {token}"));
+            }
+
+            if let Some(session_id) = headers.remove("session_id") {
+                channel_builder.session_id = Uuid::from_str(&session_id).unwrap()
+            }
+
+            if let Some(use_ssl) = headers.remove("use_ssl") {
+                if use_ssl.to_lowercase() == "true" {
+                    #[cfg(not(feature = "tls"))]
+                    {
+                        panic!(
+                        "The 'use_ssl' option requires the 'tls' feature, but it's not enabled!"
+                    );
+                    };
+                    channel_builder.use_ssl = true
+                }
+            };
+
+            if !headers.is_empty() {
+                channel_builder.headers = Some(metadata_builder(&headers));
+            }
+        }
+
+        Ok(channel_builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_builder_default() {
+        let expected_url = "http://localhost:15002".to_string();
+
+        let cb = ChannelBuilder::default();
+
+        assert_eq!(expected_url, cb.endpoint())
+    }
+
+    #[test]
+    fn test_panic_incorrect_url_scheme() {
+        let connection = "http://127.0.0.1:15002";
+
+        assert!(ChannelBuilder::create(connection).is_err())
+    }
+
+    #[test]
+    fn test_panic_missing_url_host() {
+        let connection = "sc://:15002";
+
+        assert!(ChannelBuilder::create(connection).is_err())
+    }
+
+    #[test]
+    fn test_panic_missing_url_port() {
+        let connection = "sc://127.0.0.1";
+
+        assert!(ChannelBuilder::create(connection).is_err())
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "The 'use_ssl' option requires the 'tls' feature, but it's not enabled!"
+    )]
+    fn test_panic_ssl() {
+        let connection = "sc://127.0.0.1:443/;use_ssl=true";
+
+        ChannelBuilder::create(&connection).unwrap();
+    }
+}

--- a/core/src/client/middleware.rs
+++ b/core/src/client/middleware.rs
@@ -1,0 +1,181 @@
+use std::str::FromStr;
+
+use std::collections::HashMap;
+use tonic::metadata::{
+    Ascii, AsciiMetadataValue, KeyAndValueRef, MetadataKey, MetadataMap, MetadataValue,
+};
+use tonic::service::Interceptor;
+use tonic::Status;
+
+#[derive(Clone, Debug)]
+pub struct MetadataInterceptor {
+    token: Option<String>,
+    metadata: Option<MetadataMap>,
+}
+
+impl Interceptor for MetadataInterceptor {
+    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
+        if let Some(header) = &self.metadata {
+            merge_metadata(req.metadata_mut(), header);
+        }
+        if let Some(token) = &self.token {
+            req.metadata_mut().insert(
+                "authorization",
+                AsciiMetadataValue::from_str(token.as_str()).unwrap(),
+            );
+        }
+
+        Ok(req)
+    }
+}
+
+impl MetadataInterceptor {
+    pub fn new(token: Option<String>, metadata: Option<MetadataMap>) -> Self {
+        MetadataInterceptor { token, metadata }
+    }
+}
+
+pub(super) fn metadata_builder(headers: &HashMap<String, String>) -> MetadataMap {
+    let mut metadata_map = MetadataMap::new();
+    for (key, val) in headers.iter() {
+        let meta_val = MetadataValue::from_str(val.as_str()).unwrap();
+        let meta_key = MetadataKey::from_str(key.as_str()).unwrap();
+
+        metadata_map.insert(meta_key, meta_val);
+    }
+
+    metadata_map
+}
+
+fn merge_metadata(metadata_into: &mut MetadataMap, metadata_from: &MetadataMap) {
+    metadata_for_each(metadata_from, |key, value| {
+        if key.to_string().starts_with("x-") {
+            metadata_into.insert(key, value.to_owned());
+        }
+    })
+}
+
+fn metadata_for_each<F>(metadata: &MetadataMap, mut f: F)
+where
+    F: FnMut(&MetadataKey<Ascii>, &MetadataValue<Ascii>),
+{
+    for kv_ref in metadata.iter() {
+        match kv_ref {
+            KeyAndValueRef::Ascii(key, value) => f(key, value),
+            KeyAndValueRef::Binary(_key, _value) => {}
+        }
+    }
+}
+
+//
+// #[derive(Clone, Debug)]
+// pub struct MetadataInterceptor {
+//     token: Option<String>,
+//     metadata: Option<MetadataMap>,
+// }
+//
+// impl Interceptor for MetadataInterceptor {
+//     fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
+//         if let Some(header) = &self.metadata {
+//             merge_metadata(req.metadata_mut(), header);
+//         }
+//         if let Some(token) = &self.token {
+//             req.metadata_mut().insert(
+//                 "authorization",
+//                 AsciiMetadataValue::from_str(token.as_str()).unwrap(),
+//             );
+//         }
+//
+//         Ok(req)
+//     }
+// }
+//
+// impl MetadataInterceptor {
+//     pub fn new(token: Option<String>, metadata: Option<MetadataMap>) -> Self {
+//         MetadataInterceptor { token, metadata }
+//     }
+// }
+//
+// pub fn metadata_builder(headers: &HashMap<String, String>) -> MetadataMap {
+//     let mut metadata_map = MetadataMap::new();
+//     for (key, val) in headers.iter() {
+//         let meta_val = MetadataValue::from_str(val.as_str()).unwrap();
+//         let meta_key = MetadataKey::from_str(key.as_str()).unwrap();
+//
+//         metadata_map.insert(meta_key, meta_val);
+//     }
+//
+//     metadata_map
+// }
+//
+// fn merge_metadata(metadata_into: &mut MetadataMap, metadata_from: &MetadataMap) {
+//     metadata_for_each(metadata_from, |key, value| {
+//         if key.to_string().starts_with("x-") {
+//             metadata_into.insert(key, value.to_owned());
+//         }
+//     })
+// }
+//
+// fn metadata_for_each<F>(metadata: &MetadataMap, mut f: F)
+// where
+//     F: FnMut(&MetadataKey<Ascii>, &MetadataValue<Ascii>),
+// {
+//     for kv_ref in metadata.iter() {
+//         match kv_ref {
+//             KeyAndValueRef::Ascii(key, value) => f(key, value),
+//             KeyAndValueRef::Binary(_key, _value) => {}
+//         }
+//     }
+// }
+//
+// pub mod service {
+//     use hyper::body::Body;
+//     use hyper::{Request, Response};
+//     use std::future::Future;
+//     use std::pin::Pin;
+//     use std::task::{Context, Poll};
+//     use tonic::body::BoxBody;
+//     use tonic::transport::Channel;
+//     use tonic::IntoRequest;
+//     use tower::Service;
+//
+//     #[derive(Debug, Clone)]
+//     pub struct AuthSvc {
+//         inner: Channel,
+//     }
+//
+//     impl AuthSvc {
+//         pub fn new(inner: Channel) -> Self {
+//             AuthSvc { inner }
+//         }
+//     }
+//
+//     impl Service<Request<BoxBody>> for AuthSvc {
+//         type Response = Response<BoxBody>;
+//         type Error = Box<dyn std::error::Error + Send + Sync>;
+//
+//         #[allow(clippy::type_complexity)]
+//         type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+//
+//         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+//             self.inner.poll_ready(cx).map_err(Into::into)
+//         }
+//
+//         fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
+//             // This is necessary because tonic internally uses `tower::buffer::Buffer`.
+//             // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
+//             // for details on why this is necessary
+//             let clone = self.inner.clone();
+//             let mut inner = std::mem::replace(&mut self.inner, clone);
+//
+//             Box::pin(async move {
+//                 // Do extra async work here...
+//                 let response = inner.call(req).await?;
+//
+//                 // let (parts, _) = response..into_parts();
+//
+//                 Ok(response)
+//             })
+//         }
+//     }
+// }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -577,7 +577,10 @@ where
             }
             Ok(None) => {
                 if self.use_reattachable_execute && !self.handler.result_complete {
-                    println!("something bad happened in the reattach");
+                    println!("something bad happened in the reattach. submitting reattach");
+                    if let Err(err) = Box::pin(self.reattach_request()).await {
+                        return Err(err);
+                    }
                 }
                 None
             }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -204,7 +204,6 @@ where
             }
             Err(err) => {
                 if self.use_reattachable_execute && self.handler.response_id.is_some() {
-                    println!("submitted release until");
                     self.release_until().await?;
                 }
                 return Err(err.into());
@@ -369,7 +368,6 @@ where
     }
 
     fn handle_response(&mut self, resp: spark::ExecutePlanResponse) -> Result<(), SparkError> {
-        println!("{:?}", resp);
         self.validate_session(&resp.session_id)?;
 
         self.handler.session_id = Some(resp.session_id);

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -1,13 +1,10 @@
-//! Generic implementation of ChannelBuilder and SparkConnectClient
-
-use std::collections::HashMap;
-use std::env;
-use std::str::FromStr;
-use std::sync::Arc;
-
 use crate::errors::SparkError;
+
 use crate::spark;
 use spark::execute_plan_response::ResponseType;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tonic::codegen::{Body, Bytes, StdError};
 
 use spark::spark_connect_service_client::SparkConnectServiceClient;
 
@@ -16,273 +13,11 @@ use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use arrow_ipc::reader::StreamReader;
 
-use tonic::codegen::{Body, Bytes, StdError};
-use tonic::metadata::{
-    Ascii, AsciiMetadataValue, KeyAndValueRef, MetadataKey, MetadataMap, MetadataValue,
-};
-use tonic::service::Interceptor;
-use tonic::Status;
+mod builder;
+mod middleware;
 
-use tokio::sync::RwLock;
-
-use url::Url;
-
-use uuid::Uuid;
-
-type Host = String;
-type Port = u16;
-type UrlParse = (Host, Port, Option<HashMap<String, String>>);
-
-/// ChannelBuilder validates a connection string
-/// based on the requirements from [Spark Documentation](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md)
-#[derive(Clone, Debug)]
-pub struct ChannelBuilder {
-    host: Host,
-    port: Port,
-    session_id: Uuid,
-    token: Option<String>,
-    user_id: Option<String>,
-    user_agent: Option<String>,
-    use_ssl: bool,
-    headers: Option<MetadataMap>,
-}
-
-impl Default for ChannelBuilder {
-    fn default() -> Self {
-        let connection = match env::var("SPARK_REMOTE") {
-            Ok(conn) => conn.to_string(),
-            Err(_) => "sc://localhost:15002".to_string(),
-        };
-
-        ChannelBuilder::create(&connection).unwrap()
-    }
-}
-
-impl ChannelBuilder {
-    pub fn new() -> Self {
-        ChannelBuilder::default()
-    }
-
-    pub fn endpoint(&self) -> String {
-        let scheme = if cfg!(feature = "tls") {
-            "https"
-        } else {
-            "http"
-        };
-
-        format!("{}://{}:{}", scheme, self.host, self.port)
-    }
-
-    pub fn token(&self) -> Option<String> {
-        self.token.to_owned()
-    }
-
-    pub fn headers(&self) -> Option<MetadataMap> {
-        self.headers.to_owned()
-    }
-
-    fn create_user_agent(user_agent: Option<&str>) -> Option<String> {
-        let user_agent = user_agent.unwrap_or("_SPARK_CONNECT_RUST");
-        let pkg_version = env!("CARGO_PKG_VERSION");
-        let os = env::consts::OS.to_lowercase();
-
-        Some(format!(
-            "{} os/{} spark_connect_rs/{}",
-            user_agent, os, pkg_version
-        ))
-    }
-
-    fn create_user_id(user_id: Option<&str>) -> Option<String> {
-        match user_id {
-            Some(user_id) => Some(user_id.to_string()),
-            None => match env::var("USER") {
-                Ok(user) => Some(user),
-                Err(_) => None,
-            },
-        }
-    }
-
-    pub fn parse_connection_string(connection: &str) -> Result<UrlParse, SparkError> {
-        let url = Url::parse(connection).map_err(|_| {
-            SparkError::InvalidConnectionUrl("Failed to parse the connection URL".to_string())
-        })?;
-
-        if url.scheme() != "sc" {
-            return Err(SparkError::InvalidConnectionUrl(
-                "The URL must start with 'sc://'. Please update the URL to follow the correct format, e.g., 'sc://hostname:port'".to_string(),
-            ));
-        };
-
-        let host = url
-            .host_str()
-            .ok_or_else(|| {
-                SparkError::InvalidConnectionUrl(
-                    "The hostname must not be empty. Please update
-                    the URL to follow the correct format, e.g., 'sc://hostname:port'."
-                        .to_string(),
-                )
-            })?
-            .to_string();
-
-        let port = url.port().ok_or_else(|| {
-            SparkError::InvalidConnectionUrl(
-                "The port must not be empty. Please update
-                    the URL to follow the correct format, e.g., 'sc://hostname:port'."
-                    .to_string(),
-            )
-        })?;
-
-        let headers = ChannelBuilder::parse_headers(url);
-
-        Ok((host, port, headers))
-    }
-
-    pub fn parse_headers(url: Url) -> Option<HashMap<String, String>> {
-        let path: Vec<&str> = url
-            .path()
-            .split(';')
-            .filter(|&pair| (pair != "/") & (!pair.is_empty()))
-            .collect();
-
-        if path.is_empty() || (path.len() == 1 && (path[0].is_empty() || path[0] == "/")) {
-            return None;
-        }
-
-        let headers: HashMap<String, String> = path
-            .iter()
-            .copied()
-            .map(|pair| {
-                let mut parts = pair.splitn(2, '=');
-                (
-                    parts.next().unwrap_or("").to_string(),
-                    parts.next().unwrap_or("").to_string(),
-                )
-            })
-            .collect();
-
-        if headers.is_empty() {
-            return None;
-        }
-
-        Some(headers)
-    }
-
-    /// Create and validate a connnection string
-    #[allow(unreachable_code)]
-    pub fn create(connection: &str) -> Result<ChannelBuilder, SparkError> {
-        let (host, port, headers) = ChannelBuilder::parse_connection_string(connection)?;
-
-        let mut channel_builder = ChannelBuilder {
-            host,
-            port,
-            session_id: Uuid::new_v4(),
-            token: None,
-            user_id: ChannelBuilder::create_user_id(None),
-            user_agent: ChannelBuilder::create_user_agent(None),
-            use_ssl: false,
-            headers: None,
-        };
-
-        let mut headers = match headers {
-            Some(headers) => headers,
-            None => return Ok(channel_builder),
-        };
-
-        channel_builder.user_id = headers
-            .remove("user_id")
-            .map(|user_id| ChannelBuilder::create_user_id(Some(&user_id)))
-            .unwrap_or_else(|| ChannelBuilder::create_user_id(None));
-
-        channel_builder.user_agent = headers
-            .remove("user_agent")
-            .map(|user_agent| ChannelBuilder::create_user_agent(Some(&user_agent)))
-            .unwrap_or_else(|| ChannelBuilder::create_user_agent(None));
-
-        if let Some(token) = headers.remove("token") {
-            channel_builder.token = Some(format!("Bearer {token}"));
-        }
-
-        if let Some(session_id) = headers.remove("session_id") {
-            channel_builder.session_id = Uuid::from_str(&session_id).unwrap()
-        }
-
-        if let Some(use_ssl) = headers.remove("use_ssl") {
-            if use_ssl.to_lowercase() == "true" {
-                #[cfg(not(feature = "tls"))]
-                {
-                    panic!(
-                        "The 'use_ssl' option requires the 'tls' feature, but it's not enabled!"
-                    );
-                };
-                channel_builder.use_ssl = true
-            }
-        };
-
-        channel_builder.headers = Some(metadata_builder(&headers));
-
-        Ok(channel_builder)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct MetadataInterceptor {
-    token: Option<String>,
-    metadata: Option<MetadataMap>,
-}
-
-impl Interceptor for MetadataInterceptor {
-    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
-        if let Some(header) = &self.metadata {
-            merge_metadata(req.metadata_mut(), header);
-        }
-        if let Some(token) = &self.token {
-            req.metadata_mut().insert(
-                "authorization",
-                AsciiMetadataValue::from_str(token.as_str()).unwrap(),
-            );
-        }
-
-        Ok(req)
-    }
-}
-
-impl MetadataInterceptor {
-    pub fn new(token: Option<String>, metadata: Option<MetadataMap>) -> Self {
-        MetadataInterceptor { token, metadata }
-    }
-}
-
-fn metadata_builder(headers: &HashMap<String, String>) -> MetadataMap {
-    let mut metadata_map = MetadataMap::new();
-    for (key, val) in headers.iter() {
-        let meta_val = MetadataValue::from_str(val.as_str()).unwrap();
-        let meta_key = MetadataKey::from_str(key.as_str()).unwrap();
-
-        metadata_map.insert(meta_key, meta_val);
-    }
-
-    metadata_map
-}
-
-fn merge_metadata(metadata_into: &mut MetadataMap, metadata_from: &MetadataMap) {
-    metadata_for_each(metadata_from, |key, value| {
-        if key.to_string().starts_with("x-") {
-            metadata_into.insert(key, value.to_owned());
-        }
-    })
-}
-
-fn metadata_for_each<F>(metadata: &MetadataMap, mut f: F)
-where
-    F: FnMut(&MetadataKey<Ascii>, &MetadataValue<Ascii>),
-{
-    for kv_ref in metadata.iter() {
-        match kv_ref {
-            KeyAndValueRef::Ascii(key, value) => f(key, value),
-            KeyAndValueRef::Binary(_key, _value) => {}
-        }
-    }
-}
+pub use builder::ChannelBuilder;
+pub use middleware::MetadataInterceptor;
 
 #[allow(dead_code)]
 #[derive(Default, Debug, Clone)]
@@ -319,45 +54,6 @@ pub struct AnalyzeHandler {
     pub(crate) get_storage_level: Option<spark::StorageLevel>,
 }
 
-impl ResponseHandler {
-    fn new() -> Self {
-        Self {
-            session_id: None,
-            operation_id: None,
-            response_id: None,
-            metrics: None,
-            observed_metrics: None,
-            schema: None,
-            batches: Vec::new(),
-            sql_command_result: None,
-            write_stream_operation_start_result: None,
-            streaming_query_command_result: None,
-            get_resources_command_result: None,
-            streaming_query_manager_command_result: None,
-            result_complete: false,
-            total_count: 0,
-        }
-    }
-}
-
-impl AnalyzeHandler {
-    fn new() -> Self {
-        Self {
-            schema: None,
-            explain: None,
-            tree_string: None,
-            is_local: None,
-            is_streaming: None,
-            input_files: None,
-            spark_version: None,
-            ddl_parse: None,
-            same_semantics: None,
-            semantic_hash: None,
-            get_storage_level: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct SparkConnectClient<T> {
     stub: Arc<RwLock<SparkConnectServiceClient<T>>>,
@@ -382,8 +78,8 @@ where
         SparkConnectClient {
             stub,
             builder,
-            handler: ResponseHandler::new(),
-            analyzer: AnalyzeHandler::new(),
+            handler: ResponseHandler::default(),
+            analyzer: AnalyzeHandler::default(),
             user_context: Some(spark::UserContext {
                 user_id: user_ref.clone(),
                 user_name: user_ref,
@@ -451,7 +147,7 @@ where
         drop(client);
 
         // clear out any prior responses
-        self.handler = ResponseHandler::new();
+        self.handler = ResponseHandler::default();
 
         while let Some(_resp) = match stream.message().await {
             Ok(Some(msg)) => {
@@ -463,9 +159,7 @@ where
             Ok(None) => {
                 if self.use_reattachable_execute && !self.handler.result_complete {
                     println!("didn't get the whole stream submitting a reattach");
-                    if let Err(err) = self.reattach_request().await {
-                        return Err(err);
-                    }
+                    self.reattach_request().await?
                 }
                 None
             }
@@ -506,7 +200,7 @@ where
         req.analyze = Some(analyze);
 
         // clear out any prior responses
-        self.analyzer = AnalyzeHandler::new();
+        self.analyzer = AnalyzeHandler::default();
 
         let mut client = self.stub.write().await;
         let resp = client.analyze_plan(req).await?.into_inner();
@@ -565,9 +259,6 @@ where
         let mut stream = client.reattach_execute(req).await?.into_inner();
         drop(client);
 
-        // clear out any prior responses
-        // self.handler = ResponseHandler::new();
-
         while let Some(_resp) = match stream.message().await {
             Ok(Some(msg)) => {
                 // Handle the message
@@ -578,9 +269,7 @@ where
             Ok(None) => {
                 if self.use_reattachable_execute && !self.handler.result_complete {
                     println!("something bad happened in the reattach. submitting reattach");
-                    if let Err(err) = Box::pin(self.reattach_request()).await {
-                        return Err(err);
-                    }
+                    Box::pin(self.reattach_request()).await?
                 }
                 None
             }
@@ -892,50 +581,5 @@ where
         self.analyzer.get_storage_level.to_owned().ok_or_else(|| {
             SparkError::AnalysisException("Storage Level response is empty".to_string())
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_channel_builder_default() {
-        let expected_url = "http://localhost:15002".to_string();
-
-        let cb = ChannelBuilder::default();
-
-        assert_eq!(expected_url, cb.endpoint())
-    }
-
-    #[test]
-    fn test_panic_incorrect_url_scheme() {
-        let connection = "http://127.0.0.1:15002";
-
-        assert!(ChannelBuilder::create(connection).is_err())
-    }
-
-    #[test]
-    fn test_panic_missing_url_host() {
-        let connection = "sc://:15002";
-
-        assert!(ChannelBuilder::create(connection).is_err())
-    }
-
-    #[test]
-    fn test_panic_missing_url_port() {
-        let connection = "sc://127.0.0.1";
-
-        assert!(ChannelBuilder::create(connection).is_err())
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "The 'use_ssl' option requires the 'tls' feature, but it's not enabled!"
-    )]
-    fn test_panic_ssl() {
-        let connection = "sc://127.0.0.1:443/;use_ssl=true";
-
-        ChannelBuilder::create(&connection).unwrap();
     }
 }

--- a/core/src/conf.rs
+++ b/core/src/conf.rs
@@ -4,20 +4,15 @@ use std::collections::HashMap;
 
 use crate::spark;
 
-use crate::client::{MetadataInterceptor, SparkConnectClient};
+use crate::client::SparkClient;
 use crate::errors::SparkError;
-
-use tonic::service::interceptor::InterceptedService;
-
-#[cfg(not(feature = "wasm"))]
-use tonic::transport::Channel;
 
 #[cfg(feature = "wasm")]
 use tonic_web_wasm_client::Client;
 
 pub struct RunTimeConfig {
     #[cfg(not(feature = "wasm"))]
-    pub(crate) client: SparkConnectClient<InterceptedService<Channel, MetadataInterceptor>>,
+    pub(crate) client: SparkClient,
 
     #[cfg(feature = "wasm")]
     pub(crate) client: SparkConnectClient<InterceptedService<Client, MetadataInterceptor>>,
@@ -36,9 +31,7 @@ pub struct RunTimeConfig {
 /// ```
 impl RunTimeConfig {
     #[cfg(not(feature = "wasm"))]
-    pub fn new(
-        client: &SparkConnectClient<InterceptedService<Channel, MetadataInterceptor>>,
-    ) -> RunTimeConfig {
+    pub fn new(client: &SparkClient) -> RunTimeConfig {
         RunTimeConfig {
             client: client.clone(),
         }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -79,7 +79,6 @@ impl SparkSessionBuilder {
 
     #[cfg(not(feature = "wasm"))]
     async fn create_client(&self) -> Result<SparkSession, SparkError> {
-        println!("{:?}", self.channel_builder.endpoint());
         let channel = Endpoint::from_shared(self.channel_builder.endpoint())
             .expect("Failed to create endpoint")
             .connect()

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -79,6 +79,7 @@ impl SparkSessionBuilder {
 
     #[cfg(not(feature = "wasm"))]
     async fn create_client(&self) -> Result<SparkSession, SparkError> {
+        println!("{:?}", self.channel_builder.endpoint());
         let channel = Endpoint::from_shared(self.channel_builder.endpoint())
             .expect("Failed to create endpoint")
             .connect()


### PR DESCRIPTION
# Description

feat(reattach): Add reattach & release logic
    - move header layer to `tower`
    - refactor pieces of the `client.rs` module

## Reattach Logic

The connect server has a setting for `reattachable`. This setting will allow a client to try to recover when it receives a partial message from the server. A partial message is one where the final streaming message does not include `ResultComplete`. This can happen when there are network issues, or the cloud provider resets the connection.

1. Initialize a `ExecutePlanRequest` with `reattachable` set to `true` and receive a `ExecutePlanResponse`
2. Process the streaming message.
3. If the streaming message returns a `Ok(None)` and the client has not received a `result_complete`, then submit a `ReattachExecuteRequest` with the last `response_id` received from the server
4. If the stream is complete and the client **did receive** a `result_complete` then submit to the server a `release_all` message.
5. If the stream ends in a error and the client has received _some_ messages, then submit to the server a `release_until` message.



# Related Issue(s)
<!---
For example:

- closes #106
--->

#71
