### PR TITLE
feat(config): add ability to control builder configurations

### DIFF
--- a/crates/connect/src/client/builder.rs
+++ b/crates/connect/src/client/builder.rs
@@ -10,9 +10,9 @@ use url::Url;
 
 use uuid::Uuid;
 
-type Host = String;
-type Port = u16;
-type UrlParse = (Host, Port, Option<HashMap<String, String>>);
+pub(crate) type Host = String;
+pub(crate) type Port = u16;
+pub(crate) type UrlParse = (Host, Port, Option<HashMap<String, String>>);
 
 /// ChannelBuilder validates a connection string
 /// based on the requirements from [Spark Documentation](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md)
@@ -44,7 +44,7 @@ impl ChannelBuilder {
         ChannelBuilder::default()
     }
 
-    pub fn endpoint(&self) -> String {
+    pub(crate) fn endpoint(&self) -> String {
         let scheme = if cfg!(feature = "tls") {
             "https"
         } else {
@@ -54,15 +54,11 @@ impl ChannelBuilder {
         format!("{}://{}:{}", scheme, self.host, self.port)
     }
 
-    pub fn token(&self) -> Option<String> {
-        self.token.to_owned()
-    }
-
-    pub fn headers(&self) -> Option<HashMap<String, String>> {
+    pub(crate) fn headers(&self) -> Option<HashMap<String, String>> {
         self.headers.to_owned()
     }
 
-    fn create_user_agent(user_agent: Option<&str>) -> Option<String> {
+    pub(crate) fn create_user_agent(user_agent: Option<&str>) -> Option<String> {
         let user_agent = user_agent.unwrap_or("_SPARK_CONNECT_RUST");
         let pkg_version = env!("CARGO_PKG_VERSION");
         let os = env::consts::OS.to_lowercase();
@@ -73,7 +69,7 @@ impl ChannelBuilder {
         ))
     }
 
-    fn create_user_id(user_id: Option<&str>) -> Option<String> {
+    pub(crate) fn create_user_id(user_id: Option<&str>) -> Option<String> {
         match user_id {
             Some(user_id) => Some(user_id.to_string()),
             None => match env::var("USER") {
@@ -83,7 +79,7 @@ impl ChannelBuilder {
         }
     }
 
-    pub fn parse_connection_string(connection: &str) -> Result<UrlParse, SparkError> {
+    pub(crate) fn parse_connection_string(connection: &str) -> Result<UrlParse, SparkError> {
         let url = Url::parse(connection).map_err(|_| {
             SparkError::InvalidConnectionUrl("Failed to parse the connection URL".to_string())
         })?;
@@ -118,7 +114,7 @@ impl ChannelBuilder {
         Ok((host, port, headers))
     }
 
-    pub fn parse_headers(url: Url) -> Option<HashMap<String, String>> {
+    pub(crate) fn parse_headers(url: Url) -> Option<HashMap<String, String>> {
         let path: Vec<&str> = url
             .path()
             .split(';')

--- a/crates/connect/src/client/builder.rs
+++ b/crates/connect/src/client/builder.rs
@@ -237,6 +237,17 @@ mod tests {
     }
 
     #[test]
+    fn test_settings_builder() {
+        let connection = "sc://myhost.com:443/;token=ABCDEFG;user_agent=some_agent;user_id=user123";
+
+        let builder = ChannelBuilder::create(connection).unwrap();
+
+        assert_eq!("http://myhost.com:443".to_string(), builder.endpoint());
+        assert_eq!("Bearer ABCDEFG".to_string(), builder.token.unwrap());
+        assert_eq!("user123".to_string(), builder.user_id.unwrap());
+    }
+
+    #[test]
     #[should_panic(
         expected = "The 'use_ssl' option requires the 'tls' feature, but it's not enabled!"
     )]

--- a/crates/connect/src/client/config.rs
+++ b/crates/connect/src/client/config.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::client::builder::{Host, Port};
+use crate::client::ChannelBuilder;
+
+/// Config handler to set custom SparkSessionBuilder options
+#[derive(Clone, Debug, Default)]
+pub struct Config {
+    pub host: Host,
+    pub port: Port,
+    pub session_id: Uuid,
+    pub token: Option<String>,
+    pub user_id: Option<String>,
+    pub user_agent: Option<String>,
+    pub use_ssl: bool,
+    pub headers: Option<HashMap<String, String>>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config {
+            host: "localhost".to_string(),
+            port: 15002,
+            token: None,
+            session_id: Uuid::new_v4(),
+            user_id: ChannelBuilder::create_user_id(None),
+            user_agent: ChannelBuilder::create_user_agent(None),
+            use_ssl: false,
+            headers: None,
+        }
+    }
+
+    pub fn host(mut self, val: &str) -> Self {
+        self.host = val.to_string();
+        self
+    }
+
+    pub fn port(mut self, val: Port) -> Self {
+        self.port = val;
+        self
+    }
+
+    pub fn token(mut self, val: &str) -> Self {
+        self.token = Some(val.to_string());
+        self
+    }
+
+    pub fn session_id(mut self, val: Uuid) -> Self {
+        self.session_id = val;
+        self
+    }
+
+    pub fn user_id(mut self, val: &str) -> Self {
+        self.user_id = Some(val.to_string());
+        self
+    }
+
+    pub fn user_agent(mut self, val: &str) -> Self {
+        self.user_agent = Some(val.to_string());
+        self
+    }
+
+    pub fn use_ssl(mut self, val: bool) -> Self {
+        self.use_ssl = val;
+        self
+    }
+
+    pub fn headers(mut self, val: HashMap<String, String>) -> Self {
+        self.headers = Some(val);
+        self
+    }
+}
+
+impl From<Config> for ChannelBuilder {
+    fn from(config: Config) -> Self {
+        // if there is a token, then it needs to be added to the headers
+        // do not overwrite any existing authentication header
+
+        let mut headers = config.headers.unwrap_or_default();
+
+        if let Some(token) = &config.token {
+            headers
+                .entry("authorization".to_string())
+                .or_insert_with(|| format!("Bearer {}", token));
+        }
+
+        Self {
+            host: config.host,
+            port: config.port,
+            session_id: config.session_id,
+            token: config.token,
+            user_id: config.user_id,
+            user_agent: config.user_agent,
+            use_ssl: config.use_ssl,
+            headers: if headers.is_empty() {
+                None
+            } else {
+                Some(headers)
+            },
+        }
+    }
+}

--- a/crates/connect/src/client/mod.rs
+++ b/crates/connect/src/client/mod.rs
@@ -22,9 +22,11 @@ use uuid::Uuid;
 use crate::errors::SparkError;
 
 mod builder;
+mod config;
 mod middleware;
 
 pub use builder::ChannelBuilder;
+pub use config::Config;
 pub use middleware::{HeadersLayer, HeadersMiddleware};
 
 pub type SparkClient = SparkConnectClient<HeadersMiddleware<Channel>>;

--- a/crates/connect/src/session.rs
+++ b/crates/connect/src/session.rs
@@ -313,22 +313,6 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn test_session_builder() {
-        let connection = "sc://myhost.com:443/;token=ABCDEFG;user_agent=some_agent;user_id=user123";
-
-        let ssbuilder = SparkSessionBuilder::remote(connection);
-
-        assert_eq!(
-            "http://myhost.com:443".to_string(),
-            ssbuilder.channel_builder.endpoint()
-        );
-        assert_eq!(
-            "Bearer ABCDEFG".to_string(),
-            ssbuilder.channel_builder.token().unwrap()
-        );
-    }
-
     #[tokio::test]
     async fn test_spark_range() -> Result<(), SparkError> {
         let spark = setup().await;

--- a/crates/connect/src/session.rs
+++ b/crates/connect/src/session.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::client::{ChannelBuilder, HeadersLayer, SparkClient, SparkConnectClient};
+use crate::client::{ChannelBuilder, Config, HeadersLayer, SparkClient, SparkConnectClient};
 
 use crate::catalog::Catalog;
 use crate::conf::RunTimeConfig;
@@ -50,6 +50,14 @@ impl SparkSessionBuilder {
 
         Self {
             channel_builder,
+            configs: HashMap::new(),
+        }
+    }
+
+    /// Create a new Spark Session from a [Config] object
+    pub fn from_config(config: Config) -> Self {
+        Self {
+            channel_builder: config.into(),
             configs: HashMap::new(),
         }
     }


### PR DESCRIPTION
# Description

feat(config): add ability to control builder configurations
  - provider finer grain control over the options used by the ChannelBuilder
  - this is so users don't have to hack together a super long connection string to get custom headers into their session

